### PR TITLE
Add per-secret bandwidth metrics

### DIFF
--- a/src/mtproto/mtproto-proxy.c
+++ b/src/mtproto/mtproto-proxy.c
@@ -203,6 +203,7 @@ struct ext_connection_ref {
 long long ext_connections, ext_connections_created;
 long long per_secret_connections[16], per_secret_connections_created[16];
 long long per_secret_connections_rejected[16];
+long long per_secret_bytes_received[16], per_secret_bytes_sent[16];
 
 struct ext_connection_ref OutExtConnections[EXT_CONN_TABLE_SIZE];
 struct ext_connection *InExtConnectionHash[EXT_CONN_HASH_SIZE];
@@ -429,6 +430,8 @@ struct worker_stats {
   long long per_secret_connections[16];
   long long per_secret_connections_created[16];
   long long per_secret_connections_rejected[16];
+  long long per_secret_bytes_received[16];
+  long long per_secret_bytes_sent[16];
 };
 
 struct worker_stats *WStats, SumStats;
@@ -500,6 +503,8 @@ static void update_local_stats_copy (struct worker_stats *S) {
     UPD (per_secret_connections[_i]);
     UPD (per_secret_connections_created[_i]);
     UPD (per_secret_connections_rejected[_i]);
+    UPD (per_secret_bytes_received[_i]);
+    UPD (per_secret_bytes_sent[_i]);
   }}
 #undef UPD
   __sync_synchronize();
@@ -588,6 +593,8 @@ static inline void add_stats (struct worker_stats *W) {
     UPD (per_secret_connections[_i]);
     UPD (per_secret_connections_created[_i]);
     UPD (per_secret_connections_rejected[_i]);
+    UPD (per_secret_bytes_received[_i]);
+    UPD (per_secret_bytes_sent[_i]);
   }}
 #undef UPD
 }
@@ -1038,6 +1045,20 @@ void mtfront_prepare_prometheus_stats (stats_buffer_t *sb) {
       for (_i = 0; _i < _sc; _i++) {
         sb_printf (sb, "teleproxy_secret_connections_rejected_total{secret=\"%s\"} %lld\n",
 	         tcp_rpcs_get_ext_secret_label (_i), S(per_secret_connections_rejected[_i]));
+      }
+      sb_printf (sb,
+	       "# HELP teleproxy_secret_bytes_received_total Bytes received from clients per secret.\n"
+	       "# TYPE teleproxy_secret_bytes_received_total counter\n");
+      for (_i = 0; _i < _sc; _i++) {
+        sb_printf (sb, "teleproxy_secret_bytes_received_total{secret=\"%s\"} %lld\n",
+	         tcp_rpcs_get_ext_secret_label (_i), S(per_secret_bytes_received[_i]));
+      }
+      sb_printf (sb,
+	       "# HELP teleproxy_secret_bytes_sent_total Bytes sent to clients per secret.\n"
+	       "# TYPE teleproxy_secret_bytes_sent_total counter\n");
+      for (_i = 0; _i < _sc; _i++) {
+        sb_printf (sb, "teleproxy_secret_bytes_sent_total{secret=\"%s\"} %lld\n",
+	         tcp_rpcs_get_ext_secret_label (_i), S(per_secret_bytes_sent[_i]));
       }
     }
   }

--- a/src/net/net-tcp-rpc-ext-server.c
+++ b/src/net/net-tcp-rpc-ext-server.c
@@ -177,6 +177,7 @@ extern long long direct_dc_connections_failed, direct_dc_connections_dc_closed;
 extern long long direct_dc_retries;
 extern long long per_secret_connections[16], per_secret_connections_created[16];
 extern long long per_secret_connections_rejected[16];
+extern long long per_secret_bytes_received[16], per_secret_bytes_sent[16];
 extern long long transport_errors_received;
 extern long long quickack_packets_received;
 
@@ -278,6 +279,10 @@ static int tcp_direct_client_parse_execute (connection_job_t C) {
     vkprintf (2, "direct client: DC not ready yet, deferring %d bytes\n", c->in.total_bytes);
     return NEED_MORE_BYTES;
   }
+  int sid = TCP_RPC_DATA(C)->extra_int2;
+  if (sid > 0 && sid <= 16 && c->in.total_bytes > 0) {
+    per_secret_bytes_received[sid - 1] += c->in.total_bytes;
+  }
   return tcp_direct_relay (C);
 }
 
@@ -295,6 +300,12 @@ static int tcp_direct_dc_parse_execute (connection_job_t C) {
     }
   }
 
+  if (c->extra && c->in.total_bytes > 0) {
+    int sid = TCP_RPC_DATA((connection_job_t) c->extra)->extra_int2;
+    if (sid > 0 && sid <= 16) {
+      per_secret_bytes_sent[sid - 1] += c->in.total_bytes;
+    }
+  }
   return tcp_direct_relay (C);
 }
 


### PR DESCRIPTION
Track bytes received/sent per secret in direct mode. Two new Prometheus counters:

- `teleproxy_secret_bytes_received_total{secret="label"}` — bytes from client
- `teleproxy_secret_bytes_sent_total{secret="label"}` — bytes to client

Prerequisite for #30 (Grafana dashboard) and #26 (data quotas).

Closes #31