### PR TITLE
release: trigger teleproxy/repo rebuild on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,18 @@ jobs:
           files: release/*
           body_path: release-notes.md
 
+      - name: Trigger RPM repo rebuild
+        if: env.TELEPROXY_REPO_DISPATCH_TOKEN != ''
+        env:
+          TELEPROXY_REPO_DISPATCH_TOKEN: ${{ secrets.TELEPROXY_REPO_DISPATCH_TOKEN }}
+        run: |
+          curl -fsSL \
+            -X POST \
+            -H "Authorization: Bearer $TELEPROXY_REPO_DISPATCH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/teleproxy/repo/dispatches \
+            -d "{\"event_type\":\"new-release\",\"client_payload\":{\"tag\":\"${GITHUB_REF_NAME}\"}}"
+
       - name: Notify Telegram
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}


### PR DESCRIPTION
Adds a step at the end of the `release` job that fires a `repository_dispatch` event to `teleproxy/repo` (the new dnf repository) after a tag is published. The repo workflow downloads the static binaries from this release, wraps them in signed RPMs with nfpm, runs `createrepo_c`, and republishes `https://teleproxy.github.io/repo/`.

The step is gated on the `TELEPROXY_REPO_DISPATCH_TOKEN` secret being present, so it's a no-op on forks and on tag pushes that don't need to fan out (e.g. release re-runs without a token rotation).

Closes #21.

## Setup required after merge

Add a fine-grained PAT as a repo secret named `TELEPROXY_REPO_DISPATCH_TOKEN` with:
- Resource access: only `teleproxy/repo`
- Permissions: `Actions: read and write`, `Metadata: read`

Without the secret the step is a no-op, so it's safe to merge first and rotate the token in afterward.

## Manual test

After the secret is set, the next `v*` tag will fan out a build at https://github.com/teleproxy/repo/actions. Existing release artifacts (`teleproxy-linux-amd64`, `teleproxy-linux-arm64`) are unchanged.

Live install once published:

```sh
dnf install https://teleproxy.github.io/repo/teleproxy-release-latest.noarch.rpm
dnf install teleproxy
systemctl enable --now teleproxy
```

Already verified end-to-end against teleproxy v4.9.0 in a Rocky 9 container with the manually-triggered build.