### PR TITLE
docs: dnf install instructions for RHEL/Rocky/Alma/Fedora

### DIFF
--- a/docs/getting-started/installation.fa.md
+++ b/docs/getting-started/installation.fa.md
@@ -79,6 +79,28 @@ curl -sSL https://raw.githubusercontent.com/teleproxy/teleproxy/main/install.sh 
 curl -sSL https://raw.githubusercontent.com/teleproxy/teleproxy/main/install.sh | TELEPROXY_VERSION=1.2.3 sh
 ```
 
+## مخزن RPM (RHEL، Rocky، Alma، Fedora)
+
+برای RHEL 9، RHEL 10، AlmaLinux، Rocky Linux و Fedora 41/42 از طریق dnf نصب کنید تا به‌روزرسانی‌ها از طریق پکیج منیجر انجام شوند:
+
+```bash
+dnf install https://teleproxy.github.io/repo/teleproxy-release-latest.noarch.rpm
+dnf install teleproxy
+systemctl enable --now teleproxy
+```
+
+نصب اول یک secret تصادفی در `/etc/teleproxy/config.toml` می‌سازد و پیام پس از نصب لینک اتصال را چاپ می‌کند. اجراهای بعدی `dnf upgrade` فقط باینری را عوض می‌کنند و هرگز کانفیگ شما را دست نمی‌زنند.
+
+مخزن با کلید GPG از نوع RSA 4096 و SHA-512 امضا شده (سازگار با rpm-sequoia در RHEL 9). پکیج setup هم `/etc/yum.repos.d/teleproxy.repo` و هم کلید عمومی را در `/etc/pki/rpm-gpg/` قرار می‌دهد.
+
+حذف:
+
+```bash
+dnf remove teleproxy
+```
+
+فایل `/etc/teleproxy/config.toml` سر جایش می‌ماند تا نصب مجدد از همان‌جایی که رها کردید ادامه پیدا کند.
+
 ## باینری استاتیک (هر لینوکسی)
 
 باینری‌های استاتیک از پیش ساخته‌شده با هر انتشار منتشر می‌شوند. این باینری‌ها به‌صورت استاتیک با musl libc لینک شده‌اند و هیچ وابستگی اجرایی ندارند. دانلود کنید و اجرا کنید.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -79,6 +79,28 @@ To pin a specific version:
 curl -sSL https://raw.githubusercontent.com/teleproxy/teleproxy/main/install.sh | TELEPROXY_VERSION=1.2.3 sh
 ```
 
+## RPM Repository (RHEL, Rocky, Alma, Fedora)
+
+For RHEL 9, RHEL 10, AlmaLinux, Rocky Linux and Fedora 41/42, install via dnf so updates flow through the package manager:
+
+```bash
+dnf install https://teleproxy.github.io/repo/teleproxy-release-latest.noarch.rpm
+dnf install teleproxy
+systemctl enable --now teleproxy
+```
+
+The first install generates a random secret in `/etc/teleproxy/config.toml`; the post-install message prints the connection link. Subsequent `dnf upgrade` runs swap the binary and never touch your config.
+
+The repository is signed with an RSA 4096 / SHA-512 GPG key (RHEL 9 rpm-sequoia compatible). The setup RPM drops both `/etc/yum.repos.d/teleproxy.repo` and the public key into `/etc/pki/rpm-gpg/`.
+
+To uninstall:
+
+```bash
+dnf remove teleproxy
+```
+
+Your `/etc/teleproxy/config.toml` is left in place so re-installs pick up where you left off.
+
 ## Static Binary (Any Linux)
 
 Pre-built static binaries are published with every release — statically linked against musl libc, zero runtime dependencies. Download and run.

--- a/docs/getting-started/installation.ru.md
+++ b/docs/getting-started/installation.ru.md
@@ -79,6 +79,28 @@ curl -sSL https://raw.githubusercontent.com/teleproxy/teleproxy/main/install.sh 
 curl -sSL https://raw.githubusercontent.com/teleproxy/teleproxy/main/install.sh | TELEPROXY_VERSION=1.2.3 sh
 ```
 
+## RPM-репозиторий (RHEL, Rocky, Alma, Fedora)
+
+Для RHEL 9, RHEL 10, AlmaLinux, Rocky Linux и Fedora 41/42 ставьте через dnf — обновления пойдут через пакетный менеджер:
+
+```bash
+dnf install https://teleproxy.github.io/repo/teleproxy-release-latest.noarch.rpm
+dnf install teleproxy
+systemctl enable --now teleproxy
+```
+
+При первой установке генерируется случайный секрет в `/etc/teleproxy/config.toml`, и пост-установочное сообщение печатает ссылку для подключения. Последующие `dnf upgrade` обновляют только бинарник и никогда не трогают ваш конфиг.
+
+Репозиторий подписан ключом RSA 4096 с SHA-512 (совместим с rpm-sequoia в RHEL 9). Setup-пакет кладёт `/etc/yum.repos.d/teleproxy.repo` и публичный ключ в `/etc/pki/rpm-gpg/`.
+
+Удаление:
+
+```bash
+dnf remove teleproxy
+```
+
+Файл `/etc/teleproxy/config.toml` остаётся на месте, чтобы при повторной установке всё подхватилось как было.
+
 ## Готовый бинарник (любой Linux)
 
 Статически собранные бинарники публикуются с каждым релизом — линковка с musl libc, никаких зависимостей. Скачайте и запускайте.

--- a/docs/getting-started/installation.vi.md
+++ b/docs/getting-started/installation.vi.md
@@ -79,6 +79,28 @@ Script sẽ thay thế binary và khởi động lại dịch vụ. Cấu hình 
 curl -sSL https://raw.githubusercontent.com/teleproxy/teleproxy/main/install.sh | TELEPROXY_VERSION=1.2.3 sh
 ```
 
+## Kho RPM (RHEL, Rocky, Alma, Fedora)
+
+Trên RHEL 9, RHEL 10, AlmaLinux, Rocky Linux và Fedora 41/42, hãy cài qua dnf để bản cập nhật đi qua trình quản lý gói:
+
+```bash
+dnf install https://teleproxy.github.io/repo/teleproxy-release-latest.noarch.rpm
+dnf install teleproxy
+systemctl enable --now teleproxy
+```
+
+Lần cài đầu sẽ sinh một secret ngẫu nhiên trong `/etc/teleproxy/config.toml` và thông điệp sau cài đặt sẽ in ra liên kết kết nối. Các lần `dnf upgrade` sau chỉ thay binary và không bao giờ động vào file cấu hình của bạn.
+
+Kho được ký bằng GPG RSA 4096 với SHA-512 (tương thích với rpm-sequoia trên RHEL 9). Gói setup đặt `/etc/yum.repos.d/teleproxy.repo` và khoá công khai vào `/etc/pki/rpm-gpg/`.
+
+Gỡ cài đặt:
+
+```bash
+dnf remove teleproxy
+```
+
+File `/etc/teleproxy/config.toml` được giữ lại để lần cài lại tiếp tục từ chỗ bạn đã dừng.
+
 ## Binary tĩnh (Mọi bản phân phối Linux)
 
 Các binary tĩnh được phát hành cùng với mỗi phiên bản - liên kết tĩnh với musl libc, không cần bất kỳ thư viện phụ thuộc nào. Tải về và chạy ngay.


### PR DESCRIPTION
Adds an RPM Repository section to the installation guide pointing users at the new teleproxy.github.io/repo. All four translations (en, ru, fa, vi) updated together to keep the i18n nav consistent.

Verified locally with \`mkdocs build --strict\`.