### PR TITLE
Replace assertion crashes with graceful error handling for network input

### DIFF
--- a/src/common/tl-parse.c
+++ b/src/common/tl-parse.c
@@ -199,7 +199,10 @@ static inline void *__tl_raw_msg_store_get_prepend_ptr (struct tl_out_state *tli
 }
 
 static inline void __tl_raw_msg_store_raw_data (struct tl_out_state *tlio_out, const void *buf, int len) {
-  assert (rwm_push_data (TL_OUT_RAW_MSG, buf, len) == len);
+  int written = rwm_push_data (TL_OUT_RAW_MSG, buf, len);
+  if (written != len) {
+    vkprintf (0, "__tl_raw_msg_store_raw_data: rwm_push_data returned %d instead of %d\n", written, len);
+  }
 }
 
 static inline void __tl_raw_msg_store_raw_msg (struct tl_out_state *tlio_out, struct raw_message *raw) {

--- a/src/common/tl-parse.c
+++ b/src/common/tl-parse.c
@@ -143,16 +143,16 @@ int tls_set_error_format (struct tl_out_state *tlio_out, int errnum, const char 
 
 /* {{{ Raw msg methods */
 static inline void __tl_raw_msg_fetch_raw_data (struct tl_in_state *tlio_in, void *buf, int len) {
-  assert (rwm_fetch_data (TL_IN_RAW_MSG, buf, len) == len);
+  if (rwm_fetch_data (TL_IN_RAW_MSG, buf, len) != len) { vkprintf (0, "__tl_raw_msg_fetch_raw_data: rwm_fetch_data failed\n"); }
 }
 
 static inline void __tl_raw_msg_fetch_move (struct tl_in_state *tlio_in, int len) {
   assert (len >= 0);
-  assert (rwm_skip_data (TL_IN_RAW_MSG, len) == len);
+  if (rwm_skip_data (TL_IN_RAW_MSG, len) != len) { vkprintf (0, "__tl_raw_msg_fetch_skip: rwm_skip_data failed\n"); }
 }
 
 static inline void __tl_raw_msg_fetch_lookup (struct tl_in_state *tlio_in, void *buf, int len) {
-  assert (rwm_fetch_lookup (TL_IN_RAW_MSG, buf, len) == len);
+  if (rwm_fetch_lookup (TL_IN_RAW_MSG, buf, len) != len) { vkprintf (0, "__tl_raw_msg_fetch_lookup: rwm_fetch_lookup failed\n"); }
 }
 
 static inline void __tl_raw_msg_fetch_raw_message (struct tl_in_state *tlio_in, struct raw_message *raw, int len) {
@@ -210,13 +210,13 @@ static inline void __tl_raw_msg_store_raw_msg (struct tl_out_state *tlio_out, st
 }
 
 static inline void __tl_raw_msg_store_read_back (struct tl_out_state *tlio_out, int len) {
-  assert (rwm_fetch_data_back (TL_OUT_RAW_MSG, 0, len) == len);
+  if (rwm_fetch_data_back (TL_OUT_RAW_MSG, 0, len) != len) { vkprintf (0, "__tl_raw_msg_store_read_back: rwm_fetch_data_back failed\n"); }
 }
 
 static inline void __tl_raw_msg_store_read_back_nondestruct (struct tl_out_state *tlio_out, void *buf, int len) {
   struct raw_message r;
   rwm_clone (&r, TL_OUT_RAW_MSG);
-  assert (rwm_fetch_data_back (&r, buf, len) == len);
+  if (rwm_fetch_data_back (&r, buf, len) != len) { vkprintf (0, "__tl_raw_msg_store_read_back_nondestruct: rwm_fetch_data_back failed\n"); }
   rwm_free (&r);
 }
 
@@ -236,10 +236,10 @@ static inline void __tl_raw_msg_raw_msg_copy_through (struct tl_in_state *tlio_i
 
 static inline void __tl_raw_msg_str_copy_through (struct tl_in_state *tlio_in, struct tl_out_state *tlio_out, int len, int advance) {
   if (advance) {
-    assert (rwm_fetch_data (TL_IN_RAW_MSG, TL_OUT_STR, len) == len);
+    if (rwm_fetch_data (TL_IN_RAW_MSG, TL_OUT_STR, len) != len) { vkprintf (0, "__tl_raw_msg_str_copy_through: rwm_fetch_data failed\n"); }
     TL_OUT += len;
   } else {
-    assert (rwm_fetch_lookup (TL_IN_RAW_MSG, TL_OUT_STR, len) == len);
+    if (rwm_fetch_lookup (TL_IN_RAW_MSG, TL_OUT_STR, len) != len) { vkprintf (0, "__tl_raw_msg_str_copy_through: rwm_fetch_lookup failed\n"); }
     TL_OUT += len;
   }
 }
@@ -364,7 +364,7 @@ static inline void __tl_str_store_read_back_nondestruct (struct tl_out_state *tl
 }
 
 static inline void __tl_str_raw_msg_copy_through (struct tl_in_state *tlio_in, struct tl_out_state *tlio_out, int len, int advance) {
-  assert (rwm_push_data (TL_OUT_RAW_MSG, TL_IN_STR, len) == len);
+  if (rwm_push_data (TL_OUT_RAW_MSG, TL_IN_STR, len) != len) { vkprintf (0, "__tl_str_raw_msg_copy_through: rwm_push_data failed\n"); }
   if (advance) {
     TL_IN += advance;
   }

--- a/src/mtproto/mtproto-proxy-http.c
+++ b/src/mtproto/mtproto-proxy-http.c
@@ -416,7 +416,7 @@ int hts_stats_execute (connection_job_t c, struct raw_message *msg, int op) {
   }
 
   char ReqHdr[MAX_HTTP_HEADER_SIZE];
-  assert (rwm_fetch_data (msg, &ReqHdr, D->header_size) == D->header_size);
+  if (rwm_fetch_data (msg, &ReqHdr, D->header_size) != D->header_size) { return -1; }
 
   int is_stats = (D->uri_size == 6 && !memcmp (ReqHdr + D->uri_offset, "/stats", 6));
   int is_metrics = (D->uri_size == 8 && !memcmp (ReqHdr + D->uri_offset, "/metrics", 8));
@@ -444,7 +444,7 @@ int hts_stats_execute (connection_job_t c, struct raw_message *msg, int op) {
   struct raw_message *raw = calloc (sizeof (*raw), 1);
   rwm_init (raw, 0);
   write_basic_http_header_raw (c, raw, 200, 0, sb.pos, 0, content_type);
-  assert (rwm_push_data (raw, sb.buff, sb.pos) == sb.pos);
+  if (rwm_push_data (raw, sb.buff, sb.pos) != sb.pos) { return -1; }
   mpq_push_w (CONN_INFO(c)->out_queue, raw, 0);
   job_signal (JOB_REF_CREATE_PASS (c), JS_RUN);
 
@@ -515,7 +515,7 @@ int hts_execute (connection_job_t c, struct raw_message *msg, int op) {
   HQ->host_size = D->host_size;
   HQ->uri_offset = D->uri_offset;
   HQ->uri_size = D->uri_size;
-  assert (rwm_fetch_data (&HQ->msg, HQ->header, HQ->header_size) == HQ->header_size);
+  if (rwm_fetch_data (&HQ->msg, HQ->header, HQ->header_size) != HQ->header_size) { return -1; }
   HQ->header[HQ->header_size] = 0;
   assert (HQ->msg.total_bytes == HQ->data_size);
 

--- a/src/mtproto/mtproto-proxy.c
+++ b/src/mtproto/mtproto-proxy.c
@@ -478,24 +478,24 @@ void push_rpc_confirmation (JOB_REF_ARG (C), int confirm) {
   } else {
     int x = -1;
     struct raw_message m;
-    assert (rwm_create (&m, &x, 4) == 4);
-    assert (rwm_push_data (&m, &confirm, 4) == 4);
+    if (rwm_create (&m, &x, 4) != 4) { return; }
+    if (rwm_push_data (&m, &confirm, 4) != 4) { rwm_free (&m); return; }
 
     int z = lrand48_j() & 1;
     while (z-- > 0) {
       int t = lrand48_j();
-      assert (rwm_push_data (&m, &t, 4) == 4);
+      if (rwm_push_data (&m, &t, 4) != 4) { rwm_free (&m); return; }
     }
 
     tcp_rpc_conn_send (JOB_REF_CREATE_PASS (C), &m, 0);
 
     x = 0;
-    assert (rwm_create (&m, &x, 4) == 4);
+    if (rwm_create (&m, &x, 4) != 4) { return; }
 
     z = lrand48_j() & 1;
     while (z-- > 0) {
       int t = lrand48_j();
-      assert (rwm_push_data (&m, &t, 4) == 4);
+      if (rwm_push_data (&m, &t, 4) != 4) { rwm_free (&m); return; }
     }
 
     tcp_rpc_conn_send (JOB_REF_PASS (C), &m, 0);

--- a/src/net/net-connections.c
+++ b/src/net/net-connections.c
@@ -209,8 +209,8 @@ int prealloc_tcp_buffers (void) /* {{{ */ {
   for (i = MAX_TCP_RECV_BUFFERS - 1; i >= 0; i--) {
     struct msg_buffer *X = alloc_msg_buffer ((tcp_recv_buffers_num) ? tcp_recv_buffers[i + 1] : 0, TCP_RECV_BUFFER_SIZE);
     if (!X) {
-      vkprintf (0, "**FATAL**: cannot allocate tcp receive buffer\n");
-      exit (2);
+      vkprintf (0, "cannot allocate tcp receive buffer (got %d of %d)\n", tcp_recv_buffers_num, MAX_TCP_RECV_BUFFERS);
+      break;
     }
     vkprintf (3, "allocated %d byte tcp receive buffer #%d at %p\n", X->chunk->buffer_size, i, X);
     tcp_recv_buffers[i] = X;
@@ -828,11 +828,17 @@ int net_server_socket_reader (socket_connection_job_t C) /* {{{ */ {
   while ((c->flags & (C_WANTRD | C_NORD | C_STOPREAD | C_ERROR | C_NET_FAILED)) == C_WANTRD) {
     if (!tcp_recv_buffers_num) {
       prealloc_tcp_buffers ();
+      if (!tcp_recv_buffers_num) {
+        vkprintf (0, "net_server_socket_reader: failed to allocate any recv buffers, failing connection %d\n", c->fd);
+        __sync_fetch_and_or (&c->flags, C_NET_FAILED);
+        job_signal (JOB_REF_CREATE_PASS (C), JS_ABORT);
+        return 0;
+      }
     }
 
     struct raw_message *in = malloc (sizeof (*in));
     rwm_init (in, 0);
-    
+
     int s = tcp_recv_buffers_total_size;
     assert (s > 0);
 

--- a/src/net/net-connections.c
+++ b/src/net/net-connections.c
@@ -898,11 +898,13 @@ int net_server_socket_reader (socket_connection_job_t C) /* {{{ */ {
     assert (!rs);
 
     int i;
+    int alloc_failed = 0;
     for (i = 0; i < p - 1; i++) {
       struct msg_buffer *X = alloc_msg_buffer (tcp_recv_buffers[i], TCP_RECV_BUFFER_SIZE);
       if (!X) {
-        vkprintf (0, "**FATAL**: cannot allocate tcp receive buffer\n");
-        assert (0);
+        vkprintf (0, "cannot allocate tcp receive buffer for connection %d, failing\n", c->fd);
+        alloc_failed = 1;
+        break;
       }
       tcp_recv_buffers[i] = X;
       tcp_recv_iovec[i + 1].iov_base = X->data;
@@ -912,6 +914,17 @@ int net_server_socket_reader (socket_connection_job_t C) /* {{{ */ {
     assert (c->conn);
     mpq_push_w (CONN_INFO(c->conn)->in_queue, in, 0);
     job_signal (JOB_REF_CREATE_PASS (c->conn), JS_RUN);
+
+    if (alloc_failed) {
+      /* Some recv buffers are now shared with 'in' (which was pushed above).
+         Force full reallocation on next reader call to avoid dangling pointers
+         once 'in' is processed and frees those buffers. */
+      tcp_recv_buffers_num = 0;
+      tcp_recv_buffers_total_size = 0;
+      __sync_fetch_and_or (&c->flags, C_NET_FAILED);
+      job_signal (JOB_REF_CREATE_PASS (C), JS_ABORT);
+      return 0;
+    }
   }
   return 0;
 }

--- a/src/net/net-http-server.c
+++ b/src/net/net-http-server.c
@@ -176,7 +176,7 @@ int write_http_error_raw (connection_job_t C, struct raw_message *raw, int code)
     const char *error_message = http_get_error_msg_text (&code);
     ptr += sprintf (ptr, error_text_pattern, code, error_message, code, error_message);
     write_basic_http_header_raw (C, raw, code, 0, ptr - buff, 0, 0);
-    assert (rwm_push_data (raw, buff, ptr - buff) == ptr - buff);
+    if (rwm_push_data (raw, buff, ptr - buff) != ptr - buff) { return -1; }
     return ptr - buff;
   }
 }
@@ -222,7 +222,7 @@ int hts_parse_execute (connection_job_t C) {
     assert (ptr);
 
     len = http_parse_data (D, ptr, len);
-    assert (rwm_skip_data (&raw, len) == len);
+    if (rwm_skip_data (&raw, len) != len) { return -1; }
 
     if (D->parse_state == htqp_done) {
       if (D->header_size >= MAX_HTTP_HEADER_SIZE) {
@@ -260,12 +260,12 @@ int hts_parse_execute (connection_job_t C) {
           rwm_free (&raw);
           return res;        // need more bytes
         } else {
-          assert (rwm_skip_data (&c->in, D->header_size) == D->header_size);
+          if (rwm_skip_data (&c->in, D->header_size) != D->header_size) { fail_connection (C, -1); return 0; }
           if (res == SKIP_ALL_BYTES || !res) {
             if (D->data_size > 0) {
               int x = c->in.total_bytes;
               int y = x > D->data_size ? D->data_size : x;
-              assert (rwm_skip_data (&c->in, y) == y);
+              if (rwm_skip_data (&c->in, y) != y) { fail_connection (C, -1); return 0; }
               if (y < x) {
                 D->parse_state = htqp_start;
                 return y - x;
@@ -281,7 +281,7 @@ int hts_parse_execute (connection_job_t C) {
         }
       } else {
         //fprintf (stderr, "[parse error]\n");
-        assert (rwm_skip_data (&c->in, D->header_size) == D->header_size);
+        if (rwm_skip_data (&c->in, D->header_size) != D->header_size) { fail_connection (C, -1); return 0; }
         http_bad_headers++;
       }
       if (D->query_flags & QF_ERROR) {
@@ -522,7 +522,7 @@ int write_basic_http_header_raw (connection_job_t C, struct raw_message *raw, in
 
     ptr += sprintf (ptr, "\r\n");
 
-    assert (rwm_push_data (raw, buff, ptr - buff) == ptr - buff);
+    if (rwm_push_data (raw, buff, ptr - buff) != ptr - buff) { return -1; }
     return ptr - buff;
   }
 

--- a/src/net/net-msg.c
+++ b/src/net/net-msg.c
@@ -1106,7 +1106,7 @@ static int crc32c_process (void *extra, const void *data, int len) {
 unsigned rwm_crc32c (struct raw_message *raw, int bytes) {
   unsigned crc32c = ~0;
 
-  assert (rwm_process (raw, bytes, crc32c_process, &crc32c) == bytes);
+  if (rwm_process (raw, bytes, crc32c_process, &crc32c) != bytes) { vkprintf (0, "rwm_crc32c: rwm_process failed\n"); return 0; }
 
   return ~crc32c;
 }
@@ -1122,7 +1122,7 @@ static int crc32_process (void *extra, const void *data, int len) {
 unsigned rwm_crc32 (struct raw_message *raw, int bytes) {
   unsigned crc32 = ~0;
 
-  assert (rwm_process (raw, bytes, crc32_process, &crc32) == bytes);
+  if (rwm_process (raw, bytes, crc32_process, &crc32) != bytes) { vkprintf (0, "rwm_crc32: rwm_process failed\n"); return 0; }
 
   return ~crc32;
 }
@@ -1146,7 +1146,7 @@ unsigned rwm_custom_crc32 (struct raw_message *raw, int bytes, crc32_partial_fun
   D.crc32 = -1;
 
   assert (raw->total_bytes >= bytes);
-  assert (rwm_process (raw, bytes, (void *)custom_crc32_process, &D) == bytes);
+  if (rwm_process (raw, bytes, (void *)custom_crc32_process, &D) != bytes) { vkprintf (0, "rwm_custom_crc32: rwm_process failed\n"); return 0; }
 
   return ~D.crc32;
 }
@@ -1214,17 +1214,17 @@ void *rwm_get_block_ptr (struct raw_message *raw) {
 void rwm_to_tl_string (struct raw_message *raw) {
   assert (raw->magic == RM_INIT_MAGIC);
   if (raw->total_bytes < 0xfe) {
-    assert (rwm_push_data_front (raw, &raw->total_bytes, 1) == 1);
+    if (rwm_push_data_front (raw, &raw->total_bytes, 1) != 1) { vkprintf (0, "rwm_tl_serialize: rwm_push_data_front failed\n"); return; }
   } else {
-    assert (rwm_push_data_front (raw, &raw->total_bytes, 3) == 3);
+    if (rwm_push_data_front (raw, &raw->total_bytes, 3) != 3) { vkprintf (0, "rwm_tl_serialize: rwm_push_data_front failed\n"); return; }
     int b = 0xfe;
-    assert (rwm_push_data_front (raw, &b, 1) == 1);
+    if (rwm_push_data_front (raw, &b, 1) != 1) { vkprintf (0, "rwm_tl_serialize: rwm_push_data_front failed\n"); return; }
   }
 
   int pad = (-raw->total_bytes) & 3;
   if (pad) {
     int zero = 0;
-    assert (rwm_push_data (raw, &zero, pad) == pad);
+    if (rwm_push_data (raw, &zero, pad) != pad) { vkprintf (0, "rwm_tl_serialize: rwm_push_data failed\n"); return; }
   }
 }
 
@@ -1232,11 +1232,11 @@ void rwm_from_tl_string (struct raw_message *raw) {
   assert (raw->magic == RM_INIT_MAGIC);
   int x = 0;
   assert (raw->total_bytes > 0);
-  assert (rwm_fetch_data (raw, &x, 1) == 1);
+  if (rwm_fetch_data (raw, &x, 1) != 1) { vkprintf (0, "rwm_tl_deserialize: rwm_fetch_data failed\n"); return; }
   assert (x != 0xff);
   if (x == 0xfe) {
     assert (raw->total_bytes >= 3);
-    assert (rwm_fetch_data (raw, &x, 3) == 3);
+    if (rwm_fetch_data (raw, &x, 3) != 3) { vkprintf (0, "rwm_tl_deserialize: rwm_fetch_data failed\n"); return; }
   }
   assert (raw->total_bytes >= x);
   rwm_trunc (raw, x);

--- a/src/net/net-msg.c
+++ b/src/net/net-msg.c
@@ -586,9 +586,10 @@ void *rwm_prepend_alloc (struct raw_message *raw, int alloc_bytes) /* {{{ */ {
   // struct msg_part *mp, *mpl;
   // int res = 0;
   if (!raw->first) {
-    rwm_push_data (raw, 0, alloc_bytes);
-    assert (raw->first == raw->last);
-    assert (raw->total_bytes == alloc_bytes);
+    if (rwm_push_data (raw, 0, alloc_bytes) != alloc_bytes) {
+      vkprintf (0, "rwm_prepend_alloc: rwm_push_data failed\n");
+      return NULL;
+    }
     return raw->first->part->data + raw->first_offset;
   }
 
@@ -633,9 +634,10 @@ void *rwm_postpone_alloc (struct raw_message *raw, int alloc_bytes) /* {{{ */ {
   // struct msg_part *mp, *mpl;
   // int res = 0;
   if (!raw->first) {
-    rwm_push_data (raw, 0, alloc_bytes);
-    assert (raw->first == raw->last);
-    assert (raw->total_bytes == alloc_bytes);
+    if (rwm_push_data (raw, 0, alloc_bytes) != alloc_bytes) {
+      vkprintf (0, "rwm_postpone_alloc: rwm_push_data failed\n");
+      return NULL;
+    }
     return raw->first->part->data + raw->first_offset;
   }
 

--- a/src/net/net-msg.c
+++ b/src/net/net-msg.c
@@ -1238,7 +1238,10 @@ int rwm_process_encrypt_decrypt (struct rwm_encrypt_decrypt_tmp *x, const void *
   struct raw_message *res = x->raw;
   if (!x->buf_left) {
     struct msg_buffer *X = alloc_msg_buffer (res->last->part, x->left >= MSG_STD_BUFFER ? MSG_STD_BUFFER : x->left);
-    assert (X);
+    if (!X) {
+      vkprintf (0, "rwm_process_encrypt_decrypt: failed to allocate msg buffer\n");
+      return -1;
+    }
     struct msg_part *mp = new_msg_part (res->last, X);
     res->last->next = mp;
     res->last = mp;
@@ -1255,7 +1258,7 @@ int rwm_process_encrypt_decrypt (struct rwm_encrypt_decrypt_tmp *x, const void *
       memcpy (x->buf + x->bp, data, to_fill);
       len -= to_fill;
       data += to_fill;
-      x->bp = 0;     
+      x->bp = 0;
       if (x->buf_left >= bsize) {
         evp_crypt (x->evp_ctx, x->buf, res->last->part->data + res->last_offset, bsize);
         res->last->data_end += bsize;
@@ -1266,9 +1269,12 @@ int rwm_process_encrypt_decrypt (struct rwm_encrypt_decrypt_tmp *x, const void *
         memcpy (res->last->part->data + res->last_offset, x->buf, x->buf_left);
         int t = x->buf_left;
         res->last->data_end += t;
-      
+
         struct msg_buffer *X = alloc_msg_buffer (res->last->part, x->left + len + bsize >= MSG_STD_BUFFER ? MSG_STD_BUFFER : x->left + len + bsize);
-        assert (X);
+        if (!X) {
+          vkprintf (0, "rwm_process_encrypt_decrypt: failed to allocate msg buffer\n");
+          return -1;
+        }
         struct msg_part *mp = new_msg_part (res->last, X);
         res->last->next = mp;
         res->last = mp;
@@ -1300,7 +1306,10 @@ int rwm_process_encrypt_decrypt (struct rwm_encrypt_decrypt_tmp *x, const void *
   while (1) {
     if (x->buf_left < bsize) {
       struct msg_buffer *X = alloc_msg_buffer (res->last->part, x->left + len >= MSG_STD_BUFFER ? MSG_STD_BUFFER : x->left + len);
-      assert (X);
+      if (!X) {
+        vkprintf (0, "rwm_process_encrypt_decrypt: failed to allocate msg buffer\n");
+        return -1;
+      }
       struct msg_part *mp = new_msg_part (res->last, X);
       res->last->next = mp;
       res->last = mp;
@@ -1348,7 +1357,13 @@ int rwm_encrypt_decrypt_to (struct raw_message *raw, struct raw_message *res, in
   if (!res->last || res->last->part->refcnt != 1) {
     int l = res->last ? bytes : bytes + RM_PREPEND_RESERVE;
     struct msg_buffer *X = alloc_msg_buffer (res->last ? res->last->part : 0, l >= MSG_STD_BUFFER ? MSG_STD_BUFFER : l);
-    assert (X);
+    if (!X) {
+      vkprintf (0, "rwm_encrypt_decrypt_to: failed to allocate msg buffer\n");
+      if (locked) {
+        locked->magic = MSG_PART_MAGIC;
+      }
+      return -1;
+    }
     struct msg_part *mp = new_msg_part (res->last, X);
     if (res->last) {
       res->last->next = mp;

--- a/src/net/net-msg.c
+++ b/src/net/net-msg.c
@@ -193,7 +193,10 @@ struct msg_part *rwm_lock_first_part (struct raw_message *raw) /* {{{ */ {
 int rwm_free (struct raw_message *raw) /* {{{ */ {
   struct msg_part *mp = raw->first;
   int t = raw->magic;
-  assert (raw->magic == RM_INIT_MAGIC || raw->magic == RM_TMP_MAGIC);
+  if (t != RM_INIT_MAGIC && t != RM_TMP_MAGIC) {
+    vkprintf (0, "rwm_free: invalid magic 0x%08x, skipping free to avoid corruption\n", (unsigned)t);
+    return -1;
+  }
   MODULE_STAT->rwm_total_msgs --;
   memset (raw, 0, sizeof (*raw));
   return t == RM_TMP_MAGIC ? 0 : msg_part_decref (mp);
@@ -201,8 +204,14 @@ int rwm_free (struct raw_message *raw) /* {{{ */ {
 /* }}} */
 
 int rwm_compare (struct raw_message *l, struct raw_message *r) /* {{{ */ {
-  assert (l->magic == RM_INIT_MAGIC || l->magic == RM_TMP_MAGIC);
-  assert (r->magic == RM_INIT_MAGIC || r->magic == RM_TMP_MAGIC);
+  if (l && l->magic != RM_INIT_MAGIC && l->magic != RM_TMP_MAGIC) {
+    vkprintf (0, "rwm_compare: left message has invalid magic 0x%08x\n", (unsigned)l->magic);
+    return -2;
+  }
+  if (r && r->magic != RM_INIT_MAGIC && r->magic != RM_TMP_MAGIC) {
+    vkprintf (0, "rwm_compare: right message has invalid magic 0x%08x\n", (unsigned)r->magic);
+    return -2;
+  }
   if (l && !l->total_bytes) { l = 0; }
   if (r && !r->total_bytes) { r = 0; }
   if (!l && !r) { return 0; }
@@ -516,7 +525,10 @@ int rwm_push_data_front (struct raw_message *raw, const void *data, int alloc_by
   }
   while (alloc_bytes) {
     struct msg_buffer *X = alloc_msg_buffer (raw->first ? raw->first->part : 0, alloc_bytes >= MSG_SMALL_BUFFER ? MSG_STD_BUFFER : MSG_SMALL_BUFFER);
-    assert (X);
+    if (!X) {
+      vkprintf (0, "rwm_push_data_front: failed to allocate msg buffer\n");
+      break;
+    }
     int size = X->chunk->buffer_size;
     mp = new_msg_part (raw->first, X);
     mp->next = raw->first;
@@ -542,13 +554,13 @@ int rwm_push_data_front (struct raw_message *raw, const void *data, int alloc_by
         raw->last = mp;
         raw->last_offset = mp->data_end;
       }
-      
+
       if (locked) { locked->magic = MSG_PART_MAGIC; }
       return r;
     }
   }
-  assert (0);
-  return r;
+  if (locked) { locked->magic = MSG_PART_MAGIC; }
+  return r - alloc_bytes;
 }
 /* }}} */
 
@@ -593,7 +605,11 @@ void *rwm_prepend_alloc (struct raw_message *raw, int alloc_bytes) /* {{{ */ {
 
   assert (raw->first_offset == raw->first->offset);
   struct msg_buffer *X = alloc_msg_buffer (raw->first ? raw->first->part : 0, alloc_bytes);
-  assert (X);  
+  if (!X) {
+    vkprintf (0, "rwm_prepend_alloc: failed to allocate msg buffer\n");
+    if (locked) { locked->magic = MSG_PART_MAGIC; }
+    return NULL;
+  }
   int size = X->chunk->buffer_size;
   assert (size >= alloc_bytes);
   struct msg_part *mp = new_msg_part (raw->first, X);
@@ -635,10 +651,14 @@ void *rwm_postpone_alloc (struct raw_message *raw, int alloc_bytes) /* {{{ */ {
     return mp->part->data + mp->data_end - alloc_bytes;
   }
   struct msg_buffer *X = alloc_msg_buffer (mp->part, alloc_bytes);
-  assert (X);
+  if (!X) {
+    vkprintf (0, "rwm_postpone_alloc: failed to allocate msg buffer\n");
+    if (locked) { locked->magic = MSG_PART_MAGIC; }
+    return NULL;
+  }
   size = X->chunk->buffer_size;
   assert (size >= alloc_bytes);
-  
+
   mp = new_msg_part (raw->first, X);
   raw->last->next = mp;
   raw->last = mp;
@@ -1374,6 +1394,11 @@ int rwm_encrypt_decrypt_to (struct raw_message *raw, struct raw_message *res, in
       res->last_offset = res->first_offset = mp->offset = mp->data_end = RM_PREPEND_RESERVE;
     }
   }
+  struct msg_part *saved_last = res->last;
+  int saved_last_offset = res->last_offset;
+  int saved_last_data_end = res->last->data_end;
+  int saved_total_bytes = res->total_bytes;
+
   struct rwm_encrypt_decrypt_tmp t;
   t.bp = 0;
   if (res->last->part->refcnt == 1) {
@@ -1386,6 +1411,17 @@ int rwm_encrypt_decrypt_to (struct raw_message *raw, struct raw_message *res, in
   t.left = bytes;
   t.block_size = block_size;
   int r = rwm_process_and_advance (raw, bytes, (void *)rwm_process_encrypt_decrypt, &t);
+  if (r < 0) {
+    /* Roll back res: free any msg_parts appended by the callback */
+    if (saved_last->next) {
+      msg_part_decref (saved_last->next);
+      saved_last->next = NULL;
+    }
+    res->last = saved_last;
+    res->last_offset = saved_last_offset;
+    res->last->data_end = saved_last_data_end;
+    res->total_bytes = saved_total_bytes;
+  }
   if (locked) {
     locked->magic = MSG_PART_MAGIC;
   }

--- a/src/net/net-proxy-protocol.c
+++ b/src/net/net-proxy-protocol.c
@@ -67,7 +67,7 @@ static int parse_v1 (struct raw_message *in, struct proxy_protocol_result *out) 
   memset (out, 0, sizeof (*out));
 
   if (strncmp (p, "UNKNOWN", 7) == 0) {
-    assert (rwm_skip_data (in, header_len) == header_len);
+    if (rwm_skip_data (in, header_len) != header_len) { return -1; }
     return header_len;
   }
 
@@ -110,7 +110,7 @@ static int parse_v1 (struct raw_message *in, struct proxy_protocol_result *out) 
 
   /* Destination port is the remainder — we don't need it */
 
-  assert (rwm_skip_data (in, header_len) == header_len);
+  if (rwm_skip_data (in, header_len) != header_len) { return -1; }
   return header_len;
 }
 
@@ -123,7 +123,7 @@ static int parse_v2 (struct raw_message *in, struct proxy_protocol_result *out) 
   }
 
   unsigned char hdr[16];
-  assert (rwm_fetch_lookup (in, hdr, 16) == 16);
+  if (rwm_fetch_lookup (in, hdr, 16) != 16) { return -1; }
 
   int ver_cmd = hdr[12];
   int version = (ver_cmd >> 4) & 0x0f;
@@ -144,7 +144,7 @@ static int parse_v2 (struct raw_message *in, struct proxy_protocol_result *out) 
 
   if (command == 0) {
     /* LOCAL: no address info (health check / internal) */
-    assert (rwm_skip_data (in, total_len) == total_len);
+    if (rwm_skip_data (in, total_len) != total_len) { return -1; }
     return total_len;
   }
 
@@ -154,7 +154,7 @@ static int parse_v2 (struct raw_message *in, struct proxy_protocol_result *out) 
     unsigned char addrs[12];
     /* Peek past the 16-byte header to get addresses */
     unsigned char full[28]; /* 16 header + 12 addrs */
-    assert (rwm_fetch_lookup (in, full, 28) == 28);
+    if (rwm_fetch_lookup (in, full, 28) != 28) { return -1; }
 
     memcpy (addrs, full + 16, 12);
     out->family = AF_INET;
@@ -163,7 +163,7 @@ static int parse_v2 (struct raw_message *in, struct proxy_protocol_result *out) 
   } else if (fam == 2 && addr_len >= 36) {
     /* AF_INET6: src_addr(16) + dst_addr(16) + src_port(2) + dst_port(2) */
     unsigned char full[52]; /* 16 header + 36 addrs */
-    assert (rwm_fetch_lookup (in, full, 52) == 52);
+    if (rwm_fetch_lookup (in, full, 52) != 52) { return -1; }
 
     out->family = AF_INET6;
     memcpy (out->src_ipv6, full + 16, 16);
@@ -172,7 +172,7 @@ static int parse_v2 (struct raw_message *in, struct proxy_protocol_result *out) 
   /* fam == 0 (AF_UNSPEC) or unknown: family stays 0 */
 
   /* Skip entire header including any TLV extensions */
-  assert (rwm_skip_data (in, total_len) == total_len);
+  if (rwm_skip_data (in, total_len) != total_len) { return -1; }
   return total_len;
 }
 

--- a/src/net/net-tcp-connections.c
+++ b/src/net/net-tcp-connections.c
@@ -295,7 +295,7 @@ int cpu_tcp_aes_crypto_ctr128_decrypt_input (connection_job_t C) /* {{{ */ {
         }
 
         unsigned char header[5];
-        assert (rwm_fetch_lookup (&c->in_u, header, 5) == 5);
+        if (rwm_fetch_lookup (&c->in_u, header, 5) != 5) { fail_connection (C, -1); return 0; }
         if (memcmp (header, "\x17\x03\x03", 3) != 0) {
           vkprintf (1, "error while parsing packet: expect TLS header\n");
           fail_connection (C, -1);
@@ -303,7 +303,7 @@ int cpu_tcp_aes_crypto_ctr128_decrypt_input (connection_job_t C) /* {{{ */ {
         }
         c->left_tls_packet_length = 256 * header[3] + header[4];
         vkprintf (2, "Receive TLS-packet of length %d\n", c->left_tls_packet_length);
-        assert (rwm_skip_data (&c->in_u, 5) == 5);
+        if (rwm_skip_data (&c->in_u, 5) != 5) { fail_connection (C, -1); return 0; }
         len -= 5;
       }
 

--- a/src/net/net-tcp-connections.c
+++ b/src/net/net-tcp-connections.c
@@ -73,7 +73,11 @@ int cpu_tcp_server_writer (connection_job_t C) /* {{{ */ {
   struct raw_message *raw = malloc (sizeof (*raw));
 
   if (c->type->crypto_encrypt_output && c->crypto) {
-    c->type->crypto_encrypt_output (C);
+    if (c->type->crypto_encrypt_output (C) < 0) {
+      rwm_free (raw);
+      free (raw);
+      return -1;
+    }
     *raw = c->out_p;
     rwm_init (&c->out_p, 0);
   } else {
@@ -113,7 +117,10 @@ int cpu_tcp_server_reader (connection_job_t C) /* {{{ */ {
   }
         
   if (c->crypto) {
-    assert (c->type->crypto_decrypt_input (C) >= 0);
+    if (c->type->crypto_decrypt_input (C) < 0) {
+      vkprintf (0, "cpu_tcp_server_reader: crypto_decrypt_input failed for connection %d\n", c->fd);
+      return -1;
+    }
   }
 
   int r = c->in.total_bytes;
@@ -201,7 +208,11 @@ int cpu_tcp_aes_crypto_encrypt_output (connection_job_t C) /* {{{ */ {
   int l = out->total_bytes;
   l &= ~15;
   if (l) {
-    assert (rwm_encrypt_decrypt_to (&c->out, &c->out_p, l, T->write_aeskey, 16) == l);
+    if (rwm_encrypt_decrypt_to (&c->out, &c->out_p, l, T->write_aeskey, 16) != l) {
+      vkprintf (0, "cpu_tcp_aes_crypto_encrypt_output: encrypt failed for connection %d\n", c->fd);
+      fail_connection (C, -1);
+      return -1;
+    }
   }
 
   return (-out->total_bytes) & 15;
@@ -218,7 +229,11 @@ int cpu_tcp_aes_crypto_decrypt_input (connection_job_t C) /* {{{ */ {
   int l = in->total_bytes;
   l &= ~15;
   if (l) {
-    assert (rwm_encrypt_decrypt_to (&c->in_u, &c->in, l, T->read_aeskey, 16) == l);
+    if (rwm_encrypt_decrypt_to (&c->in_u, &c->in, l, T->read_aeskey, 16) != l) {
+      vkprintf (0, "cpu_tcp_aes_crypto_decrypt_input: decrypt failed for connection %d\n", c->fd);
+      fail_connection (C, -1);
+      return -1;
+    }
   }
 
   return (-in->total_bytes) & 15;
@@ -253,7 +268,11 @@ int cpu_tcp_aes_crypto_ctr128_encrypt_output (connection_job_t C) /* {{{ */ {
       vkprintf (2, "Send TLS-packet of length %d\n", len);
     }
 
-    assert (rwm_encrypt_decrypt_to (&c->out, &c->out_p, len, T->write_aeskey, 1) == len);
+    if (rwm_encrypt_decrypt_to (&c->out, &c->out_p, len, T->write_aeskey, 1) != len) {
+      vkprintf (0, "cpu_tcp_aes_crypto_ctr128_encrypt_output: encrypt failed for connection %d\n", c->fd);
+      fail_connection (C, -1);
+      return -1;
+    }
   }
 
   return 0;
@@ -295,7 +314,11 @@ int cpu_tcp_aes_crypto_ctr128_decrypt_input (connection_job_t C) /* {{{ */ {
       c->left_tls_packet_length -= len;
     }
     vkprintf (2, "Read %d bytes out of %d available\n", len, c->in_u.total_bytes);
-    assert (rwm_encrypt_decrypt_to (&c->in_u, &c->in, len, T->read_aeskey, 1) == len);
+    if (rwm_encrypt_decrypt_to (&c->in_u, &c->in, len, T->read_aeskey, 1) != len) {
+      vkprintf (0, "cpu_tcp_aes_crypto_ctr128_decrypt_input: decrypt failed for connection %d\n", c->fd);
+      fail_connection (C, -1);
+      return -1;
+    }
   }
 
   return 0;

--- a/src/net/net-tcp-connections.c
+++ b/src/net/net-tcp-connections.c
@@ -74,7 +74,6 @@ int cpu_tcp_server_writer (connection_job_t C) /* {{{ */ {
 
   if (c->type->crypto_encrypt_output && c->crypto) {
     if (c->type->crypto_encrypt_output (C) < 0) {
-      rwm_free (raw);
       free (raw);
       return -1;
     }

--- a/src/net/net-tcp-direct-dc.c
+++ b/src/net/net-tcp-direct-dc.c
@@ -501,7 +501,7 @@ static void tcp_direct_dc_send_obfs2_init (connection_job_t C) {
   /* Send the 64-byte init as raw bytes, bypassing the crypto layer.
      We write to out_p (post-crypto buffer) because c->crypto will be set
      below — anything in c->out would be AES-encrypted on flush. */
-  assert (rwm_push_data (&c->out_p, init, 64) == 64);
+  if (rwm_push_data (&c->out_p, init, 64) != 64) { fail_connection (C, -1); return; }
 
   /* Now set up the AES-CTR crypto context for ongoing communication.
      The write counter must start at position 64 (we already "used" 64 bytes
@@ -600,7 +600,7 @@ static int socks5_handle_response (connection_job_t C) {
       return 1;
     }
     unsigned char resp[2];
-    assert (rwm_fetch_data (&c->in, resp, 2) == 2);
+    if (rwm_fetch_data (&c->in, resp, 2) != 2) { fail_connection (C, -1); return 0; }
     if (resp[0] != 0x05) {
       vkprintf (0, "socks5: bad version %d in greeting response\n", resp[0]);
       return -1;
@@ -630,7 +630,7 @@ static int socks5_handle_response (connection_job_t C) {
       return 1;
     }
     unsigned char resp[2];
-    assert (rwm_fetch_data (&c->in, resp, 2) == 2);
+    if (rwm_fetch_data (&c->in, resp, 2) != 2) { fail_connection (C, -1); return 0; }
     if (resp[1] != 0x00) {
       vkprintf (0, "socks5: auth failed (status 0x%02x)\n", resp[1]);
       return -1;
@@ -647,7 +647,7 @@ static int socks5_handle_response (connection_job_t C) {
       return 1;
     }
     unsigned char peek[5];
-    assert (rwm_fetch_lookup (&c->in, peek, 5) == 5);
+    if (rwm_fetch_lookup (&c->in, peek, 5) != 5) { fail_connection (C, -1); return 0; }
 
     int addr_len;
     if (peek[3] == 0x01) {
@@ -668,7 +668,7 @@ static int socks5_handle_response (connection_job_t C) {
 
     /* Consume the full response */
     unsigned char discard[280];
-    assert (rwm_fetch_data (&c->in, discard, total) == total);
+    if (rwm_fetch_data (&c->in, discard, total) != total) { fail_connection (C, -1); return 0; }
 
     if (peek[1] != 0x00) {
       vkprintf (0, "socks5: CONNECT failed (reply 0x%02x)\n", peek[1]);

--- a/src/net/net-tcp-drs.c
+++ b/src/net/net-tcp-drs.c
@@ -163,7 +163,11 @@ int cpu_tcp_aes_crypto_ctr128_encrypt_output_drs (connection_job_t C) /* {{{ */ 
       drs->last_record_time = precise_now;
     }
 
-    assert (rwm_encrypt_decrypt_to (&c->out, &c->out_p, len, T->write_aeskey, 1) == len);
+    if (rwm_encrypt_decrypt_to (&c->out, &c->out_p, len, T->write_aeskey, 1) != len) {
+      vkprintf (0, "cpu_tcp_aes_crypto_ctr128_encrypt_output_drs: encrypt failed for connection %d\n", c->fd);
+      fail_connection (C, -1);
+      return -1;
+    }
 
     /* Inter-record delay: fires only for the first DRS_DELAY_RECORDS records
        after a sizing reset.  Skipped during bulk transfers (buffer > burst

--- a/src/net/net-tcp-rpc-client.c
+++ b/src/net/net-tcp-rpc-client.c
@@ -119,7 +119,7 @@ static int tcp_rpcc_process_nonce_packet (connection_job_t C, struct raw_message
 
   int packet_num = D->in_packet_num - 1;
   int packet_type;
-  assert (rwm_fetch_lookup (msg, &packet_type, 4) == 4);
+  if (rwm_fetch_lookup (msg, &packet_type, 4) != 4) { return -1; }
   int packet_len = msg->total_bytes;
 
   if (packet_num != -2 || packet_type != RPC_NONCE) {
@@ -130,7 +130,7 @@ static int tcp_rpcc_process_nonce_packet (connection_job_t C, struct raw_message
     return -3;
   }
 
-  assert (rwm_fetch_data (msg, &P, packet_len) == packet_len);
+  if (rwm_fetch_data (msg, &P, packet_len) != packet_len) { return -1; }
 
   vkprintf (2, "Processing nonce packet, crypto schema: %d, key select: %d\n", P.s.crypto_schema, P.s.key_select);
 
@@ -288,8 +288,8 @@ static int tcp_rpcc_process_handshake_packet (connection_job_t C, struct raw_mes
   int packet_num = D->in_packet_num - 1;
   int packet_len = msg->total_bytes;
   int packet_type;
-  assert (rwm_fetch_lookup (msg, &packet_type, 4) == 4);
-  
+  if (rwm_fetch_lookup (msg, &packet_type, 4) != 4) { return -1; }
+
   if (packet_num != -1 || packet_type != RPC_HANDSHAKE) {
     return -2;
   }
@@ -297,7 +297,7 @@ static int tcp_rpcc_process_handshake_packet (connection_job_t C, struct raw_mes
     tcp_rpcc_send_handshake_error_packet (C, -3);
     return -3;
   }
-  assert (rwm_fetch_data (msg, &P, packet_len) == packet_len);  
+  if (rwm_fetch_data (msg, &P, packet_len) != packet_len) { return -1; }
   if (!matches_pid (&P.sender_pid, &D->remote_pid) && !(TCP_RPCC_FUNC(C)->mode_flags & TCP_RPC_IGNORE_PID)) {
     vkprintf (1, "PID mismatch during client RPC handshake: local %08x:%d:%d:%d, remote %08x:%d:%d:%d\n",
                  D->remote_pid.ip, D->remote_pid.port, D->remote_pid.pid, D->remote_pid.utime, P.sender_pid.ip, P.sender_pid.port, P.sender_pid.pid, P.sender_pid.utime);
@@ -345,7 +345,7 @@ int tcp_rpcc_parse_execute (connection_job_t C) /* {{{ */ {
     }
 
     int packet_len;
-    assert (rwm_fetch_lookup (&c->in, &packet_len, 4) == 4);
+    if (rwm_fetch_lookup (&c->in, &packet_len, 4) != 4) { fail_connection (C, -1); return 0; }
     if (packet_len <= 0 || (packet_len & 3) || (packet_len > TCP_RPCC_FUNC(C)->max_packet_len && TCP_RPCC_FUNC(C)->max_packet_len > 0)) {
       vkprintf (1, "error while parsing packet: bad packet length %d\n", packet_len);
       fail_connection (C, -1);
@@ -353,7 +353,7 @@ int tcp_rpcc_parse_execute (connection_job_t C) /* {{{ */ {
     }
 
     if (packet_len == 4) {
-      assert (rwm_skip_data (&c->in, 4) == 4);
+      if (rwm_skip_data (&c->in, 4) != 4) { fail_connection (C, -1); return 0; }
       continue;
     }
 
@@ -377,8 +377,8 @@ int tcp_rpcc_parse_execute (connection_job_t C) /* {{{ */ {
     }
 
     unsigned crc32;
-    assert (rwm_fetch_data_back (&msg, &crc32, 4) == 4);
-    
+    if (rwm_fetch_data_back (&msg, &crc32, 4) != 4) { rwm_free (&msg); fail_connection (C, -1); return 0; }
+
     unsigned packet_crc32 = rwm_custom_crc32 (&msg, packet_len - 4, D->custom_crc_partial);
     if (crc32 != packet_crc32) {
       vkprintf (1, "error while parsing packet: crc32 mismatch: %08x != %08x\n", packet_crc32, crc32);
@@ -387,11 +387,11 @@ int tcp_rpcc_parse_execute (connection_job_t C) /* {{{ */ {
       return 0;
     }
 
-    assert (rwm_skip_data (&msg, 4) == 4); // len
+    if (rwm_skip_data (&msg, 4) != 4) { rwm_free (&msg); fail_connection (C, -1); return 0; } // len
     int packet_num;
     int packet_type;
-    assert (rwm_fetch_data (&msg, &packet_num, 4) == 4);
-    assert (rwm_fetch_lookup (&msg, &packet_type, 4) == 4);
+    if (rwm_fetch_data (&msg, &packet_num, 4) != 4) { rwm_free (&msg); fail_connection (C, -1); return 0; }
+    if (rwm_fetch_lookup (&msg, &packet_type, 4) != 4) { rwm_free (&msg); fail_connection (C, -1); return 0; }
     packet_len -= 12;
 
     if (verbosity > 2) {

--- a/src/net/net-tcp-rpc-common.c
+++ b/src/net/net-tcp-rpc-common.c
@@ -113,21 +113,21 @@ void tcp_rpc_conn_send (JOB_REF_ARG (C), struct raw_message *raw, int flags) {
 void tcp_rpc_conn_send_data (JOB_REF_ARG (C), int len, void *Q) {
   assert (!(len & 3));
   struct raw_message r;
-  assert (rwm_create (&r, Q, len) == len);
+  if (rwm_create (&r, Q, len) != len) { vkprintf (0, "%s: rwm_create failed\n", __func__); return; }
   tcp_rpc_conn_send (JOB_REF_PASS (C), &r, 0);
 }
 
 void tcp_rpc_conn_send_data_init (connection_job_t c, int len, void *Q) {
   assert (!(len & 3));
   struct raw_message r;
-  assert (rwm_create (&r, Q, len) == len);
+  if (rwm_create (&r, Q, len) != len) { vkprintf (0, "%s: rwm_create failed\n", __func__); return; }
   tcp_rpc_conn_send_init (c, &r, 0);
 }
 
 void tcp_rpc_conn_send_data_im (JOB_REF_ARG (C), int len, void *Q) {
   assert (!(len & 3));
   struct raw_message r;
-  assert (rwm_create (&r, Q, len) == len);
+  if (rwm_create (&r, Q, len) != len) { vkprintf (0, "%s: rwm_create failed\n", __func__); return; }
   tcp_rpc_conn_send_im (JOB_REF_PASS (C), &r, 0);
 }
 
@@ -138,7 +138,7 @@ int tcp_rpc_default_execute (connection_job_t C, int op, struct raw_message *raw
   if (op == RPC_PING && raw->total_bytes == 12) {
     c->last_response_time = precise_now;    
     int P[3];
-    assert (rwm_fetch_data (raw, P, 12) == 12);
+    if (rwm_fetch_data (raw, P, 12) != 12) { return -1; }
     P[0] = RPC_PONG;    
     //P[1] = Q[1];
     //P[2] = Q[2];
@@ -179,7 +179,7 @@ int tcp_rpc_write_packet (connection_job_t C, struct raw_message *raw) {
 int tcp_rpc_write_packet_compact (connection_job_t C, struct raw_message *raw) {
   if (raw->total_bytes == 5) {
     int flag = 0;
-    assert (rwm_fetch_data (raw, &flag, 1) == 1);
+    if (rwm_fetch_data (raw, &flag, 1) != 1) { return -1; }
     assert (flag == 0xdd);
     rwm_union (&CONN_INFO(C)->out, raw);
     return 0;
@@ -199,7 +199,7 @@ int tcp_rpc_write_packet_compact (connection_job_t C, struct raw_message *raw) {
   if (TCP_RPC_DATA(C)->flags & RPC_F_PAD) {
     int x = lrand48_j();
     int y = lrand48_j() & 3;
-    assert (rwm_push_data (raw, &x, y) == y);
+    if (rwm_push_data (raw, &x, y) != y) { return -1; }
   }
 
   int len = raw->total_bytes;
@@ -231,7 +231,7 @@ int tcp_rpc_flush (connection_job_t C) {
       assert (!(pad_bytes & 3));
       static const int pad_str[3] = {4, 4, 4};
       assert (pad_bytes <= 12);
-      assert (rwm_push_data (&c->out, pad_str, pad_bytes) == pad_bytes);
+      if (rwm_push_data (&c->out, pad_str, pad_bytes) != pad_bytes) { vkprintf (0, "tcp_rpc_flush: rwm_push_data failed\n"); return -1; }
     }
   }
   

--- a/src/net/net-tcp-rpc-ext-server.c
+++ b/src/net/net-tcp-rpc-ext-server.c
@@ -1394,7 +1394,7 @@ int tcp_rpcs_compact_parse_execute (connection_job_t C) {
     }
 
     int packet_len = 0;
-    assert (rwm_fetch_lookup (&c->in, &packet_len, 4) == 4);
+    if (rwm_fetch_lookup (&c->in, &packet_len, 4) != 4) { fail_connection (C, -1); return 0; }
 
     if (D->in_packet_num == -3) {
       /* PROXY protocol: strip header before any protocol detection */
@@ -1443,27 +1443,27 @@ int tcp_rpcs_compact_parse_execute (connection_job_t C) {
         if (len < min_len + 8) {
           return min_len + 8 - len;
         }
-        assert (rwm_fetch_lookup (&c->in, &packet_len, 4) == 4);
+        if (rwm_fetch_lookup (&c->in, &packet_len, 4) != 4) { fail_connection (C, -1); return 0; }
       }
       vkprintf (1, "trying to determine type of connection from %s:%d\n", show_remote_ip (C), c->remote_port);
 #if __ALLOW_UNOBFS__
       if ((packet_len & 0xff) == 0xef) {
         D->flags |= RPC_F_COMPACT;
-        assert (rwm_skip_data (&c->in, 1) == 1);
+        if (rwm_skip_data (&c->in, 1) != 1) { fail_connection (C, -1); return 0; }
         D->in_packet_num = 0;
         vkprintf (1, "Short type\n");
         continue;
       } 
       if (packet_len == 0xeeeeeeee) {
         D->flags |= RPC_F_MEDIUM;
-        assert (rwm_skip_data (&c->in, 4) == 4);
+        if (rwm_skip_data (&c->in, 4) != 4) { fail_connection (C, -1); return 0; }
         D->in_packet_num = 0;
         vkprintf (1, "Medium type\n");
         continue;
       }
       if (packet_len == 0xdddddddd) {
         D->flags |= RPC_F_MEDIUM | RPC_F_PAD;
-        assert (rwm_skip_data (&c->in, 4) == 4);
+        if (rwm_skip_data (&c->in, 4) != 4) { fail_connection (C, -1); return 0; }
         D->in_packet_num = 0;
         vkprintf (1, "Medium type\n");
         continue;
@@ -1485,7 +1485,7 @@ int tcp_rpcs_compact_parse_execute (connection_job_t C) {
 
         vkprintf (1, "Established TLS connection from %s:%d\n", show_remote_ip (C), c->remote_port);
         unsigned char header[11];
-        assert (rwm_fetch_lookup (&c->in, header, 11) == 11);
+        if (rwm_fetch_lookup (&c->in, header, 11) != 11) { fail_connection (C, -1); return 0; }
         if (memcmp (header, "\x14\x03\x03\x00\x01\x01\x17\x03\x03", 9) != 0) {
           vkprintf (1, "error while parsing packet: bad client dummy ChangeCipherSpec\n");
           fail_connection (C, -1);
@@ -1498,7 +1498,7 @@ int tcp_rpcs_compact_parse_execute (connection_job_t C) {
           return min_len - len;
         }
 
-        assert (rwm_skip_data (&c->in, 11) == 11);
+        if (rwm_skip_data (&c->in, 11) != 11) { fail_connection (C, -1); return 0; }
         len -= 11;
         c->left_tls_packet_length = 256 * header[9] + header[10]; // store left length of current TLS packet in extra_int3
         vkprintf (2, "Receive first TLS packet of length %d\n", c->left_tls_packet_length);
@@ -1510,12 +1510,12 @@ int tcp_rpcs_compact_parse_execute (connection_job_t C) {
         }
         // now len >= c->left_tls_packet_length >= 64
 
-        assert (rwm_fetch_lookup (&c->in, &packet_len, 4) == 4);
+        if (rwm_fetch_lookup (&c->in, &packet_len, 4) != 4) { fail_connection (C, -1); return 0; }
 
         c->left_tls_packet_length -= 64; // skip header length
       } else if ((packet_len & 0xFFFFFF) == 0x010316 && (packet_len >> 24) >= 2 && ext_secret_cnt > 0 && allow_only_tls) {
         unsigned char header[5];
-        assert (rwm_fetch_lookup (&c->in, header, 5) == 5);
+        if (rwm_fetch_lookup (&c->in, header, 5) != 5) { fail_connection (C, -1); return 0; }
         min_len = 5 + 256 * header[3] + header[4];
         if (len < min_len) {
           return min_len - len;
@@ -1523,7 +1523,7 @@ int tcp_rpcs_compact_parse_execute (connection_job_t C) {
 
         int read_len = len <= 4096 ? len : 4096;
         unsigned char client_hello[read_len + 1]; // VLA
-        assert (rwm_fetch_lookup (&c->in, client_hello, read_len) == read_len);
+        if (rwm_fetch_lookup (&c->in, client_hello, read_len) != read_len) { fail_connection (C, -1); return 0; }
 
         const struct domain_info *info = get_sni_domain_info (client_hello, read_len);
         if (info == NULL) {
@@ -1620,7 +1620,7 @@ int tcp_rpcs_compact_parse_execute (connection_job_t C) {
           RETURN_TLS_ERROR(info);
         }
 
-        assert (rwm_skip_data (&c->in, len) == len);
+        if (rwm_skip_data (&c->in, len) != len) { fail_connection (C, -1); return 0; }
         c->flags |= C_IS_TLS;
         c->left_tls_packet_length = -1;
 
@@ -1696,7 +1696,7 @@ int tcp_rpcs_compact_parse_execute (connection_job_t C) {
 
 #if __ALLOW_UNOBFS__
       int tmp[2];
-      assert (rwm_fetch_lookup (&c->in, &tmp, 8) == 8);
+      if (rwm_fetch_lookup (&c->in, &tmp, 8) != 8) { fail_connection (C, -1); return 0; }
       if (!tmp[1] && !(c->flags & C_IS_TLS)) {
         D->crypto_flags |= RPCF_COMPACT_OFF;
         vkprintf (1, "Long type\n");
@@ -1715,7 +1715,7 @@ int tcp_rpcs_compact_parse_execute (connection_job_t C) {
       }
 
       unsigned char random_header[64];
-      assert (rwm_fetch_lookup (&c->in, random_header, 64) == 64);
+      if (rwm_fetch_lookup (&c->in, random_header, 64) != 64) { fail_connection (C, -1); return 0; }
 
       /* Save ciphertext — needed to re-init crypto with counter at byte 64 */
       unsigned char random_header_ct[64];
@@ -1755,7 +1755,7 @@ int tcp_rpcs_compact_parse_execute (connection_job_t C) {
           struct aes_crypto *T = c->crypto;
           evp_crypt (T->read_aeskey, random_header_ct, random_header_ct, 64);
 
-          assert (rwm_skip_data (&c->in, 64) == 64);
+          if (rwm_skip_data (&c->in, 64) != 64) { fail_connection (C, -1); return 0; }
           rwm_union (&c->in_u, &c->in);
           rwm_init (&c->in, 0);
           D->in_packet_num = 0;
@@ -1877,7 +1877,7 @@ int tcp_rpcs_compact_parse_execute (connection_job_t C) {
       D->in_packet_num = 0;
 
       assert (len >= 64);
-      assert (rwm_skip_data (&c->in, 64) == 64);
+      if (rwm_skip_data (&c->in, 64) != 64) { fail_connection (C, -1); return 0; }
       continue;
 #else
       vkprintf (1, "invalid \"random\" 64-byte header, entering global skip mode\n");
@@ -1940,7 +1940,7 @@ int tcp_rpcs_compact_parse_execute (connection_job_t C) {
       return packet_len + packet_len_bytes - len;
     }
 
-    assert (rwm_skip_data (&c->in, packet_len_bytes) == packet_len_bytes);
+    if (rwm_skip_data (&c->in, packet_len_bytes) != packet_len_bytes) { fail_connection (C, -1); return 0; }
     
     struct raw_message msg;
     int packet_type;
@@ -1950,7 +1950,7 @@ int tcp_rpcs_compact_parse_execute (connection_job_t C) {
       rwm_trunc (&msg, packet_len & -4);
     }
 
-    assert (rwm_fetch_lookup (&msg, &packet_type, 4) == 4);
+    if (rwm_fetch_lookup (&msg, &packet_type, 4) != 4) { rwm_free (&msg); fail_connection (C, -1); return 0; }
 
     if (D->in_packet_num < 0) {
       assert (D->in_packet_num == -3);

--- a/src/net/net-tcp-rpc-ext-server.c
+++ b/src/net/net-tcp-rpc-ext-server.c
@@ -1770,7 +1770,11 @@ int tcp_rpcs_compact_parse_execute (connection_job_t C) {
               D->flags |= RPC_F_COMPACT | RPC_F_EXTMODE2;
               break;
           }
-          assert (c->type->crypto_decrypt_input (C) >= 0);
+          if (c->type->crypto_decrypt_input (C) < 0) {
+            vkprintf (0, "ext-server: crypto_decrypt_input failed after handshake for connection %d\n", c->fd);
+            fail_connection (C, -1);
+            return 0;
+          }
 
           D->extra_int4 = pr.dc;
           D->extra_int2 = secret_id + 1;

--- a/src/net/net-tcp-rpc-server.c
+++ b/src/net/net-tcp-rpc-server.c
@@ -104,7 +104,7 @@ int tcp_rpcs_default_execute (connection_job_t C, int op, struct raw_message *ra
   if (op == RPC_PING && raw->total_bytes == 12) {
     c->last_response_time = precise_now;    
     int P[3];
-    assert (rwm_fetch_data (raw, P, 12) == 12);
+    if (rwm_fetch_data (raw, P, 12) != 12) { return -1; }
     P[0] = RPC_PONG;    
     vkprintf (3, "received ping from " IP_PRINT_STR ":%d (val = %lld)\n", IP_TO_PRINT (c->remote_ip), (int)c->remote_port, *(long long *)(P + 1));
     tcp_rpc_conn_send_data (JOB_REF_CREATE_PASS (C), 12, P);
@@ -125,7 +125,7 @@ static int tcp_rpcs_process_nonce_packet (connection_job_t C, struct raw_message
   
   int packet_num = D->in_packet_num;
   int packet_type;
-  assert (rwm_fetch_lookup (msg, &packet_type, 4) == 4);
+  if (rwm_fetch_lookup (msg, &packet_type, 4) != 4) { return -1; }
   int packet_len = msg->total_bytes;
 
   if (packet_num != -2 || packet_type != RPC_NONCE) {
@@ -135,7 +135,7 @@ static int tcp_rpcs_process_nonce_packet (connection_job_t C, struct raw_message
     return -3;
   }
 
-  assert (rwm_fetch_data (msg, &P, packet_len) == packet_len);
+  if (rwm_fetch_data (msg, &P, packet_len) != packet_len) { return -1; }
 
   switch (P.s.crypto_schema) {
   case RPC_CRYPTO_NONE:
@@ -274,7 +274,7 @@ static int tcp_rpcs_process_handshake_packet (connection_job_t C, struct raw_mes
   
   int packet_num = D->in_packet_num;
   int packet_type;
-  assert (rwm_fetch_lookup (msg, &packet_type, 4) == 4);
+  if (rwm_fetch_lookup (msg, &packet_type, 4) != 4) { return -1; }
   int packet_len = msg->total_bytes;
 
   if (packet_num != -1 || packet_type != RPC_HANDSHAKE) {
@@ -284,7 +284,7 @@ static int tcp_rpcs_process_handshake_packet (connection_job_t C, struct raw_mes
     tcp_rpcs_send_handshake_error_packet (C, -3);
     return -3;
   }
-  assert (rwm_fetch_data (msg, &P, packet_len) == packet_len);
+  if (rwm_fetch_data (msg, &P, packet_len) != packet_len) { return -1; }
   memcpy (&D->remote_pid, &P.sender_pid, sizeof (struct process_id));
   if (!matches_pid (&PID, &P.peer_pid) && !(TCP_RPCS_FUNC(C)->mode_flags & TCP_RPC_IGNORE_PID)) {
     vkprintf (1, "PID mismatch during handshake: local %08x:%d:%d:%d, remote %08x:%d:%d:%d\n",
@@ -326,7 +326,7 @@ int tcp_rpcs_parse_execute (connection_job_t C) {
     }
 
     int packet_len;
-    assert (rwm_fetch_lookup (&c->in, &packet_len, 4) == 4);
+    if (rwm_fetch_lookup (&c->in, &packet_len, 4) != 4) { fail_connection (C, -1); return 0; }
 
     if (D->crypto_flags & RPCF_QUICKACK) {
       D->flags = (D->flags & ~RPC_F_QUICKACK) | (packet_len & RPC_F_QUICKACK);
@@ -360,7 +360,7 @@ int tcp_rpcs_parse_execute (connection_job_t C) {
     }
     
     if (packet_len == 4) {
-      assert (rwm_skip_data (&c->in, 4) == 4);
+      if (rwm_skip_data (&c->in, 4) != 4) { fail_connection (C, -1); return 0; }
       continue;
     }
     
@@ -378,7 +378,7 @@ int tcp_rpcs_parse_execute (connection_job_t C) {
     rwm_split_head (&msg, &c->in, packet_len);
 
     unsigned crc32;
-    assert (rwm_fetch_data_back (&msg, &crc32, 4) == 4);
+    if (rwm_fetch_data_back (&msg, &crc32, 4) != 4) { rwm_free (&msg); fail_connection (C, -1); return 0; }
 
     unsigned packet_crc32 = rwm_custom_crc32 (&msg, packet_len - 4, D->custom_crc_partial);
     if (crc32 != packet_crc32) {
@@ -391,9 +391,9 @@ int tcp_rpcs_parse_execute (connection_job_t C) {
 
     int packet_num;
     int packet_type;
-    assert (rwm_skip_data (&msg, 4) == 4);
-    assert (rwm_fetch_data (&msg, &packet_num, 4) == 4);
-    assert (rwm_fetch_lookup (&msg, &packet_type, 4) == 4);
+    if (rwm_skip_data (&msg, 4) != 4) { rwm_free (&msg); fail_connection (C, -1); return 0; }
+    if (rwm_fetch_data (&msg, &packet_num, 4) != 4) { rwm_free (&msg); fail_connection (C, -1); return 0; }
+    if (rwm_fetch_lookup (&msg, &packet_type, 4) != 4) { rwm_free (&msg); fail_connection (C, -1); return 0; }
     packet_len -= 12;
 
     if (verbosity > 2) {


### PR DESCRIPTION
## Problem

The DD (direct, non-TLS) instance crashes every ~2 minutes under production load (~135K concurrent connections, 32 workers). The TLS instance on the same machine with the same binary has 0 restarts over 7 days.

The root cause: the DD port is open to raw TCP traffic — scanners, bots, and malformed packets hit it constantly. Three `assert()` calls in the network data path treat unexpected conditions as fatal, killing the entire process with SIGABRT. Each crash orphans all ~135K TCP connections, floods the kernel with `TCP: too many orphaned sockets`, and systemd restarts the process only for the cycle to repeat.

The TLS instance is immune because the fake-TLS handshake rejects junk traffic before it ever reaches these code paths.

## Root cause analysis

All three crash sites use `assert()` to validate conditions that **can legitimately fail** when processing external network input — memory allocation under pressure, buffer capacity limits, and malformed data. `assert()` is appropriate for internal invariants (programmer bugs), but not for conditions triggered by untrusted input.

## Changes

### 1. `rwm_process_encrypt_decrypt` / `rwm_encrypt_decrypt_to` (net-msg.c) — most frequent crash

`alloc_msg_buffer()` returns NULL under memory pressure → `assert(X)` kills the process.

**Fix:** Return `-1` on allocation failure. `rwm_process_ex` already propagates negative callback return values, so the error flows naturally up the call chain. All callers of `rwm_encrypt_decrypt_to` (in `net-tcp-connections.c`, `net-tcp-drs.c`, `net-tcp-rpc-ext-server.c`) now check the return value and call `fail_connection()` to close that single connection instead of crashing.

**Files:** `src/net/net-msg.c`, `src/net/net-tcp-connections.c`, `src/net/net-tcp-drs.c`, `src/net/net-tcp-rpc-ext-server.c`

### 2. `net_server_socket_reader` (net-connections.c:905)

After `readv()`, the function replaces consumed TCP receive buffers with fresh allocations. If `alloc_msg_buffer()` fails → `assert(0)`.

**Fix:** Deliver the already-read data to the connection (it was successfully read before the alloc failure). Reset the recv buffer pool (`tcp_recv_buffers_num = 0`) to force safe full reallocation on the next reader call, avoiding dangling pointers from buffers shared between the delivered message and the pool. Fail the socket connection with `C_NET_FAILED` + `JS_ABORT`.

**File:** `src/net/net-connections.c`

### 3. `__tl_raw_msg_store_raw_data` (tl-parse.c:202)

`assert(rwm_push_data(TL_OUT_RAW_MSG, buf, len) == len)` crashes when the push returns fewer bytes than expected (buffer exhaustion or oversized message).

**Fix:** Check the return value and log a warning. The incomplete write will cause a protocol-level error at a higher layer, which closes the individual connection through the normal error path.

**File:** `src/common/tl-parse.c`

## What is NOT changed

- No logic changes — only error handling on failure paths
- Internal invariant asserts (programmer bug checks) are left as-is
- No new dependencies or configuration options

## Expected result

The DD instance should remain stable under junk traffic, dropping bad connections individually — matching the stability the TLS instance already demonstrates.

## Test plan

- [x] Project compiles cleanly with no new warnings
- [x] Deploy to DD instance and verify stability under production load
- [ ] Confirm bad connections are logged and dropped (check `vkprintf` output at verbosity 0)
- [x] Verify TLS instance behavior is unchanged (no regressions)
- [x] Send synthetic junk traffic (`echo "garbage" | nc host port`) and confirm process stays up