### PR TITLE
Handle buffer allocation failures gracefully instead of crashing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -289,7 +289,7 @@ jobs:
         sudo apt-get install -y build-essential libssl-dev zlib1g-dev git curl vim-common python3 python3-pip python3-venv netcat-openbsd
         python3 -m venv .venv
         source .venv/bin/activate
-        pip install requests telethon TelethonFakeTLS
+        pip install -r tests/requirements.txt
 
     - name: Build Teleproxy
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,9 @@ jobs:
     - name: Run DC Probes Tests
       run: make test-dc-probes
 
+    - name: Run Junk Traffic Resilience Test
+      run: make test-junk
+
     - name: Test install.sh config generation
       run: make test-install-config
 

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ DEPDIRS := ${DEP} $(addprefix ${DEP}/,${PROJECTS})
 ALLDIRS := ${DEPDIRS} ${OBJDIRS}
 
 
-.PHONY:	all clean lint tests test test-tls test-multi-secret test-secret-limit test-secret-quota test-rate-limit test-top-ips test-ip-acl test-drs-delays test-cdn-dc test-ipv6-direct test-dc-lookup test-config-reload test-secret-drain test-check test-link test-link-ip test-stats-port test-install-config test-proxy-protocol test-dc-probes docker-image-amd64 docker-run-help-amd64 docker-image-arm64 docker-run-help-arm64 fuzz fuzz-run
+.PHONY:	all clean lint tests test test-tls test-multi-secret test-secret-limit test-secret-quota test-rate-limit test-top-ips test-ip-acl test-drs-delays test-cdn-dc test-ipv6-direct test-dc-lookup test-config-reload test-secret-drain test-check test-link test-link-ip test-stats-port test-install-config test-proxy-protocol test-dc-probes test-junk docker-image-amd64 docker-run-help-amd64 docker-image-arm64 docker-run-help-arm64 fuzz fuzz-run
 
 EXELIST	:= ${EXE}/teleproxy
 
@@ -424,6 +424,15 @@ test-autosecret:
 		(echo "Auto-secret test failed"; \
 		docker compose -f tests/docker-compose.autosecret-test.yml down; exit 1)
 	docker compose -f tests/docker-compose.autosecret-test.yml down
+
+test-junk:
+	@export TELEPROXY_SECRET=$$(head -c 16 /dev/urandom | xxd -ps) && \
+	echo "Using secret: $$TELEPROXY_SECRET" && \
+	timeout 120s docker compose -f tests/docker-compose.junk-test.yml up --build --exit-code-from tester || \
+		(echo "Junk traffic test failed"; \
+		docker compose -f tests/docker-compose.junk-test.yml logs teleproxy; \
+		docker compose -f tests/docker-compose.junk-test.yml down; exit 1)
+	docker compose -f tests/docker-compose.junk-test.yml down
 
 test-stats-port:
 	@export TELEPROXY_SECRET=$$(head -c 16 /dev/urandom | xxd -ps) && \

--- a/src/mtproto/mtproto-proxy-http.c
+++ b/src/mtproto/mtproto-proxy-http.c
@@ -444,7 +444,12 @@ int hts_stats_execute (connection_job_t c, struct raw_message *msg, int op) {
   struct raw_message *raw = calloc (sizeof (*raw), 1);
   rwm_init (raw, 0);
   write_basic_http_header_raw (c, raw, 200, 0, sb.pos, 0, content_type);
-  assert (rwm_push_data (raw, sb.buff, sb.pos) == sb.pos);
+  if (rwm_push_data (raw, sb.buff, sb.pos) != sb.pos) {
+    rwm_free (raw);
+    free (raw);
+    sb_release (&sb);
+    return -1;
+  }
   mpq_push_w (CONN_INFO(c)->out_queue, raw, 0);
   job_signal (JOB_REF_CREATE_PASS (c), JS_RUN);
 

--- a/src/net/net-connections.c
+++ b/src/net/net-connections.c
@@ -209,8 +209,8 @@ int prealloc_tcp_buffers (void) /* {{{ */ {
   for (i = MAX_TCP_RECV_BUFFERS - 1; i >= 0; i--) {
     struct msg_buffer *X = alloc_msg_buffer ((tcp_recv_buffers_num) ? tcp_recv_buffers[i + 1] : 0, TCP_RECV_BUFFER_SIZE);
     if (!X) {
-      vkprintf (0, "**FATAL**: cannot allocate tcp receive buffer\n");
-      exit (2);
+      vkprintf (0, "cannot allocate tcp receive buffer (got %d of %d)\n", tcp_recv_buffers_num, MAX_TCP_RECV_BUFFERS);
+      break;
     }
     vkprintf (3, "allocated %d byte tcp receive buffer #%d at %p\n", X->chunk->buffer_size, i, X);
     tcp_recv_buffers[i] = X;
@@ -828,6 +828,12 @@ int net_server_socket_reader (socket_connection_job_t C) /* {{{ */ {
   while ((c->flags & (C_WANTRD | C_NORD | C_STOPREAD | C_ERROR | C_NET_FAILED)) == C_WANTRD) {
     if (!tcp_recv_buffers_num) {
       prealloc_tcp_buffers ();
+      if (!tcp_recv_buffers_num) {
+        vkprintf (0, "net_server_socket_reader: failed to allocate recv buffers, failing connection %d\n", c->fd);
+        __sync_fetch_and_or (&c->flags, C_NET_FAILED);
+        job_signal (JOB_REF_CREATE_PASS (C), JS_ABORT);
+        return 0;
+      }
     }
 
     struct raw_message *in = malloc (sizeof (*in));
@@ -898,11 +904,13 @@ int net_server_socket_reader (socket_connection_job_t C) /* {{{ */ {
     assert (!rs);
 
     int i;
+    int alloc_failed = 0;
     for (i = 0; i < p - 1; i++) {
       struct msg_buffer *X = alloc_msg_buffer (tcp_recv_buffers[i], TCP_RECV_BUFFER_SIZE);
       if (!X) {
-        vkprintf (0, "**FATAL**: cannot allocate tcp receive buffer\n");
-        assert (0);
+        vkprintf (0, "cannot allocate tcp receive buffer for connection %d\n", c->fd);
+        alloc_failed = 1;
+        break;
       }
       tcp_recv_buffers[i] = X;
       tcp_recv_iovec[i + 1].iov_base = X->data;
@@ -912,6 +920,14 @@ int net_server_socket_reader (socket_connection_job_t C) /* {{{ */ {
     assert (c->conn);
     mpq_push_w (CONN_INFO(c->conn)->in_queue, in, 0);
     job_signal (JOB_REF_CREATE_PASS (c->conn), JS_RUN);
+
+    if (alloc_failed) {
+      tcp_recv_buffers_num = 0;
+      tcp_recv_buffers_total_size = 0;
+      __sync_fetch_and_or (&c->flags, C_NET_FAILED);
+      job_signal (JOB_REF_CREATE_PASS (C), JS_ABORT);
+      return 0;
+    }
   }
   return 0;
 }

--- a/src/net/net-http-server.c
+++ b/src/net/net-http-server.c
@@ -176,7 +176,9 @@ int write_http_error_raw (connection_job_t C, struct raw_message *raw, int code)
     const char *error_message = http_get_error_msg_text (&code);
     ptr += sprintf (ptr, error_text_pattern, code, error_message, code, error_message);
     write_basic_http_header_raw (C, raw, code, 0, ptr - buff, 0, 0);
-    assert (rwm_push_data (raw, buff, ptr - buff) == ptr - buff);
+    if (rwm_push_data (raw, buff, ptr - buff) != ptr - buff) {
+      return -1;
+    }
     return ptr - buff;
   }
 }
@@ -522,7 +524,9 @@ int write_basic_http_header_raw (connection_job_t C, struct raw_message *raw, in
 
     ptr += sprintf (ptr, "\r\n");
 
-    assert (rwm_push_data (raw, buff, ptr - buff) == ptr - buff);
+    if (rwm_push_data (raw, buff, ptr - buff) != ptr - buff) {
+      return -1;
+    }
     return ptr - buff;
   }
 

--- a/src/net/net-msg-buffers.c
+++ b/src/net/net-msg-buffers.c
@@ -167,6 +167,11 @@ struct msg_buffers_chunk *alloc_new_msg_buffers_chunk (struct msg_buffers_chunk 
     // ML
     return 0;
   }
+#ifdef FAULT_ALLOC_LIMIT
+  if (allocated_buffer_chunks >= FAULT_ALLOC_LIMIT) {
+    return 0;
+  }
+#endif
   struct msg_buffers_chunk *C = malloc (MSG_BUFFERS_CHUNK_SIZE);
   if (!C) {
     return 0;

--- a/src/net/net-msg.c
+++ b/src/net/net-msg.c
@@ -1238,7 +1238,9 @@ int rwm_process_encrypt_decrypt (struct rwm_encrypt_decrypt_tmp *x, const void *
   struct raw_message *res = x->raw;
   if (!x->buf_left) {
     struct msg_buffer *X = alloc_msg_buffer (res->last->part, x->left >= MSG_STD_BUFFER ? MSG_STD_BUFFER : x->left);
-    assert (X);
+    if (!X) {
+      return -1;
+    }
     struct msg_part *mp = new_msg_part (res->last, X);
     res->last->next = mp;
     res->last = mp;
@@ -1268,7 +1270,9 @@ int rwm_process_encrypt_decrypt (struct rwm_encrypt_decrypt_tmp *x, const void *
         res->last->data_end += t;
       
         struct msg_buffer *X = alloc_msg_buffer (res->last->part, x->left + len + bsize >= MSG_STD_BUFFER ? MSG_STD_BUFFER : x->left + len + bsize);
-        assert (X);
+        if (!X) {
+          return -1;
+        }
         struct msg_part *mp = new_msg_part (res->last, X);
         res->last->next = mp;
         res->last = mp;
@@ -1300,7 +1304,9 @@ int rwm_process_encrypt_decrypt (struct rwm_encrypt_decrypt_tmp *x, const void *
   while (1) {
     if (x->buf_left < bsize) {
       struct msg_buffer *X = alloc_msg_buffer (res->last->part, x->left + len >= MSG_STD_BUFFER ? MSG_STD_BUFFER : x->left + len);
-      assert (X);
+      if (!X) {
+        return -1;
+      }
       struct msg_part *mp = new_msg_part (res->last, X);
       res->last->next = mp;
       res->last = mp;
@@ -1348,7 +1354,12 @@ int rwm_encrypt_decrypt_to (struct raw_message *raw, struct raw_message *res, in
   if (!res->last || res->last->part->refcnt != 1) {
     int l = res->last ? bytes : bytes + RM_PREPEND_RESERVE;
     struct msg_buffer *X = alloc_msg_buffer (res->last ? res->last->part : 0, l >= MSG_STD_BUFFER ? MSG_STD_BUFFER : l);
-    assert (X);
+    if (!X) {
+      if (locked) {
+        locked->magic = MSG_PART_MAGIC;
+      }
+      return -1;
+    }
     struct msg_part *mp = new_msg_part (res->last, X);
     if (res->last) {
       res->last->next = mp;
@@ -1359,6 +1370,12 @@ int rwm_encrypt_decrypt_to (struct raw_message *raw, struct raw_message *res, in
       res->last_offset = res->first_offset = mp->offset = mp->data_end = RM_PREPEND_RESERVE;
     }
   }
+
+  struct msg_part *saved_last = res->last;
+  int saved_last_offset = res->last_offset;
+  int saved_last_data_end = res->last->data_end;
+  int saved_total_bytes = res->total_bytes;
+
   struct rwm_encrypt_decrypt_tmp t;
   t.bp = 0;
   if (res->last->part->refcnt == 1) {
@@ -1371,6 +1388,16 @@ int rwm_encrypt_decrypt_to (struct raw_message *raw, struct raw_message *res, in
   t.left = bytes;
   t.block_size = block_size;
   int r = rwm_process_and_advance (raw, bytes, (void *)rwm_process_encrypt_decrypt, &t);
+  if (r < 0) {
+    if (saved_last->next) {
+      msg_part_decref (saved_last->next);
+      saved_last->next = NULL;
+    }
+    res->last = saved_last;
+    res->last_offset = saved_last_offset;
+    res->last->data_end = saved_last_data_end;
+    res->total_bytes = saved_total_bytes;
+  }
   if (locked) {
     locked->magic = MSG_PART_MAGIC;
   }

--- a/src/net/net-tcp-connections.c
+++ b/src/net/net-tcp-connections.c
@@ -73,7 +73,10 @@ int cpu_tcp_server_writer (connection_job_t C) /* {{{ */ {
   struct raw_message *raw = malloc (sizeof (*raw));
 
   if (c->type->crypto_encrypt_output && c->crypto) {
-    c->type->crypto_encrypt_output (C);
+    if (c->type->crypto_encrypt_output (C) < 0) {
+      free (raw);
+      return -1;
+    }
     *raw = c->out_p;
     rwm_init (&c->out_p, 0);
   } else {
@@ -113,7 +116,9 @@ int cpu_tcp_server_reader (connection_job_t C) /* {{{ */ {
   }
         
   if (c->crypto) {
-    assert (c->type->crypto_decrypt_input (C) >= 0);
+    if (c->type->crypto_decrypt_input (C) < 0) {
+      return -1;
+    }
   }
 
   int r = c->in.total_bytes;
@@ -201,7 +206,10 @@ int cpu_tcp_aes_crypto_encrypt_output (connection_job_t C) /* {{{ */ {
   int l = out->total_bytes;
   l &= ~15;
   if (l) {
-    assert (rwm_encrypt_decrypt_to (&c->out, &c->out_p, l, T->write_aeskey, 16) == l);
+    if (rwm_encrypt_decrypt_to (&c->out, &c->out_p, l, T->write_aeskey, 16) != l) {
+      fail_connection (C, -1);
+      return -1;
+    }
   }
 
   return (-out->total_bytes) & 15;
@@ -218,7 +226,10 @@ int cpu_tcp_aes_crypto_decrypt_input (connection_job_t C) /* {{{ */ {
   int l = in->total_bytes;
   l &= ~15;
   if (l) {
-    assert (rwm_encrypt_decrypt_to (&c->in_u, &c->in, l, T->read_aeskey, 16) == l);
+    if (rwm_encrypt_decrypt_to (&c->in_u, &c->in, l, T->read_aeskey, 16) != l) {
+      fail_connection (C, -1);
+      return -1;
+    }
   }
 
   return (-in->total_bytes) & 15;
@@ -253,7 +264,10 @@ int cpu_tcp_aes_crypto_ctr128_encrypt_output (connection_job_t C) /* {{{ */ {
       vkprintf (2, "Send TLS-packet of length %d\n", len);
     }
 
-    assert (rwm_encrypt_decrypt_to (&c->out, &c->out_p, len, T->write_aeskey, 1) == len);
+    if (rwm_encrypt_decrypt_to (&c->out, &c->out_p, len, T->write_aeskey, 1) != len) {
+      fail_connection (C, -1);
+      return -1;
+    }
   }
 
   return 0;
@@ -295,7 +309,10 @@ int cpu_tcp_aes_crypto_ctr128_decrypt_input (connection_job_t C) /* {{{ */ {
       c->left_tls_packet_length -= len;
     }
     vkprintf (2, "Read %d bytes out of %d available\n", len, c->in_u.total_bytes);
-    assert (rwm_encrypt_decrypt_to (&c->in_u, &c->in, len, T->read_aeskey, 1) == len);
+    if (rwm_encrypt_decrypt_to (&c->in_u, &c->in, len, T->read_aeskey, 1) != len) {
+      fail_connection (C, -1);
+      return -1;
+    }
   }
 
   return 0;

--- a/src/net/net-tcp-drs.c
+++ b/src/net/net-tcp-drs.c
@@ -163,7 +163,10 @@ int cpu_tcp_aes_crypto_ctr128_encrypt_output_drs (connection_job_t C) /* {{{ */ 
       drs->last_record_time = precise_now;
     }
 
-    assert (rwm_encrypt_decrypt_to (&c->out, &c->out_p, len, T->write_aeskey, 1) == len);
+    if (rwm_encrypt_decrypt_to (&c->out, &c->out_p, len, T->write_aeskey, 1) != len) {
+      fail_connection (C, -1);
+      return -1;
+    }
 
     /* Inter-record delay: fires only for the first DRS_DELAY_RECORDS records
        after a sizing reset.  Skipped during bulk transfers (buffer > burst

--- a/src/net/net-tcp-rpc-ext-server.c
+++ b/src/net/net-tcp-rpc-ext-server.c
@@ -1770,7 +1770,10 @@ int tcp_rpcs_compact_parse_execute (connection_job_t C) {
               D->flags |= RPC_F_COMPACT | RPC_F_EXTMODE2;
               break;
           }
-          assert (c->type->crypto_decrypt_input (C) >= 0);
+          if (c->type->crypto_decrypt_input (C) < 0) {
+            fail_connection (C, -1);
+            return 0;
+          }
 
           D->extra_int4 = pr.dc;
           D->extra_int2 = secret_id + 1;

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -3,6 +3,6 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 ENV PYTHONUNBUFFERED=1
-COPY test_proxy.py test_tls_e2e.py test_tls_fingerprint.py test_multi_secret_tls.py test_ip_acl.py test_direct_e2e.py test_secret_limit.py test_secret_quota.py test_secret_drain.py test_rate_limit.py test_top_ips.py test_drs_delays_e2e.py test_cdn_dc.py test_ipv6_direct.py test_bind_address.py test_config_reload.py test_socks5.py test_link_ip.py test_proxy_protocol.py test_dc_probes.py test_autosecret.py ./
+COPY test_proxy.py test_tls_e2e.py test_tls_fingerprint.py test_multi_secret_tls.py test_ip_acl.py test_direct_e2e.py test_secret_limit.py test_secret_quota.py test_secret_drain.py test_rate_limit.py test_top_ips.py test_drs_delays_e2e.py test_cdn_dc.py test_ipv6_direct.py test_bind_address.py test_config_reload.py test_socks5.py test_link_ip.py test_proxy_protocol.py test_dc_probes.py test_autosecret.py test_junk_traffic.py ./
 CMD ["python", "test_proxy.py"]
 

--- a/tests/Dockerfile.junk
+++ b/tests/Dockerfile.junk
@@ -1,0 +1,31 @@
+# Test-only build with fault injection for buffer allocation.
+# Limits the number of buffer chunk allocations to trigger the
+# alloc_msg_buffer failure path that crashes under production load.
+FROM alpine:3.21 AS builder
+
+RUN apk add --no-cache build-base openssl-dev zlib-dev linux-headers git libunwind-dev
+
+WORKDIR /src
+COPY . .
+
+# FAULT_ALLOC_LIMIT: after this many chunk allocations, alloc_new_msg_buffers_chunk
+# returns NULL. Set low enough to trigger under modest load, high enough for startup.
+ARG FAULT_ALLOC_LIMIT=3
+RUN make clean && make -j$(nproc) EXTRA_CFLAGS="-DFAULT_ALLOC_LIMIT=${FAULT_ALLOC_LIMIT}"
+
+FROM alpine:3.21
+
+RUN apk add --no-cache curl ca-certificates openssl zlib iproute2 libunwind
+RUN adduser -D -H -s /sbin/nologin teleproxy
+WORKDIR /opt/teleproxy
+COPY --from=builder /src/objs/bin/teleproxy /opt/teleproxy/
+RUN chmod +x /opt/teleproxy/teleproxy && ln -s teleproxy /opt/teleproxy/mtproto-proxy
+# Skip proxy-secret download (direct mode doesn't need it)
+RUN mkdir -p /opt/teleproxy/data
+COPY start.sh /opt/teleproxy/start.sh
+RUN chmod +x /opt/teleproxy/start.sh
+
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=60s \
+    CMD curl -f http://localhost:${STATS_PORT:-8888}/stats || exit 1
+
+ENTRYPOINT ["/opt/teleproxy/start.sh"]

--- a/tests/docker-compose.junk-test.yml
+++ b/tests/docker-compose.junk-test.yml
@@ -1,0 +1,41 @@
+services:
+  teleproxy:
+    build:
+      context: ..
+      dockerfile: tests/Dockerfile.junk
+      args:
+        # Allow 2 buffer chunk allocations (1 for 2KB recv buffers, 1 for
+        # 512B HTTP headers). Enough for startup + healthcheck.
+        # Partial connections fill the 2KB chunk (~1000 buffers), so the
+        # next allocation needs chunk #3 → denied → alloc_msg_buffer=NULL.
+        FAULT_ALLOC_LIMIT: 2
+    environment:
+      - SECRET=${TELEPROXY_SECRET}
+      - PORT=8443
+      - STATS_PORT=8888
+      - WORKERS=1
+      - DIRECT_MODE=true
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8888/stats || exit 1"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+      start_period: 5s
+
+  tester:
+    build: .
+    environment:
+      - TELEPROXY_HOST=teleproxy
+      - TELEPROXY_PORT=8443
+      - TELEPROXY_STATS_PORT=8888
+      # Fill chunk with partial connections, then burst to trigger failure
+      # ~2032 buffers total in 2 chunks. 128 for recv pool = 1904 free.
+      # Fill chunk with partial connections, then burst triggers the
+      # recv buffer replacement failure → assert(0) on buggy code.
+      - PARTIAL_CONNS=1910
+      - PARTIAL_BYTES=10
+      - BURST_CONNS=50
+    depends_on:
+      teleproxy:
+        condition: service_healthy
+    command: ["python", "test_junk_traffic.py"]

--- a/tests/fault_alloc.c
+++ b/tests/fault_alloc.c
@@ -1,0 +1,61 @@
+/*
+ * Fault injection for alloc_msg_buffer testing.
+ *
+ * LD_PRELOAD this to make malloc() return NULL for allocations of
+ * MSG_BUFFERS_CHUNK_SIZE after a configurable number of successes.
+ * This reliably triggers the assert(0) in net_server_socket_reader
+ * and other allocation-failure code paths without needing extreme load.
+ *
+ * Environment variables:
+ *   FAULT_ALLOC_FAIL_AFTER=N  — allow N chunk allocations, then fail
+ *
+ * Build:
+ *   cc -shared -fPIC -o fault_alloc.so fault_alloc.c -ldl
+ */
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+/* Must match MSG_BUFFERS_CHUNK_SIZE in net-msg-buffers.h */
+#define CHUNK_SIZE ((1L << 21) - 64)
+
+static int fail_after = 0;
+static int chunk_count = 0;
+static void *(*real_malloc)(size_t) = NULL;
+
+__attribute__((constructor))
+static void fault_alloc_init(void) {
+    real_malloc = dlsym(RTLD_NEXT, "malloc");
+    const char *val = getenv("FAULT_ALLOC_FAIL_AFTER");
+    if (val) {
+        fail_after = atoi(val);
+        fprintf(stderr, "fault_alloc: will fail chunk allocations after %d\n",
+                fail_after);
+    }
+}
+
+void *malloc(size_t size) {
+    if (!real_malloc) {
+        /* Before constructor runs — use a static buffer for tiny allocs */
+        static char bootstrap[4096];
+        static size_t offset = 0;
+        if (offset + size <= sizeof(bootstrap)) {
+            void *p = bootstrap + offset;
+            offset += (size + 15) & ~15;
+            return p;
+        }
+        return NULL;
+    }
+
+    if (fail_after > 0 && size == CHUNK_SIZE) {
+        chunk_count++;
+        if (chunk_count > fail_after) {
+            fprintf(stderr, "fault_alloc: failing chunk alloc #%d (limit %d)\n",
+                    chunk_count, fail_after);
+            return NULL;
+        }
+    }
+
+    return real_malloc(size);
+}

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 requests
-telethon
+telethon>=1.42,<1.43.0
 TelethonFakeTLS

--- a/tests/test_junk_traffic.py
+++ b/tests/test_junk_traffic.py
@@ -86,7 +86,7 @@ def main():
             s.sendall(partial_data)
             partial_sockets.append(s)
         except OSError:
-            pass
+            pass  # connection failures expected under buffer pressure
         if (i + 1) % 200 == 0:
             print(f"  Opened {i + 1}/{PARTIAL_CONNS}...")
 
@@ -105,7 +105,7 @@ def main():
             try:
                 s.close()
             except OSError:
-                pass
+                pass  # best-effort cleanup, socket may already be reset
         check("survived_partial_fill", False, "died before burst")
         print(f"\nResults: {passed} passed, {failed} failed")
         sys.exit(1 if failed else 0)
@@ -126,7 +126,7 @@ def main():
             s.sendall(burst_data)
             s.close()
         except OSError:
-            pass
+            pass  # connection failures expected under buffer pressure
 
     # Brief pause for crash to manifest
     time.sleep(3)
@@ -150,7 +150,7 @@ def main():
         try:
             s.close()
         except OSError:
-            pass
+            pass  # best-effort cleanup, socket may already be reset
     print(f"  Closed {opened} partial connections")
 
     # Step 7: Verify proxy still works after cleanup

--- a/tests/test_junk_traffic.py
+++ b/tests/test_junk_traffic.py
@@ -1,0 +1,167 @@
+"""Test that buffer allocation failures don't crash the proxy.
+
+Reproduces the crash from GitHub PR #54: when alloc_msg_buffer() returns NULL
+under memory pressure, assert() kills the process with SIGABRT.
+
+Strategy: open many partial connections that each send less than 64 bytes (the
+obfs2 header size). The proxy buffers the partial data in c->in, holding one
+2KB buffer per connection indefinitely. This fills the buffer chunk (~1000
+buffers). The next allocation needs a new chunk, which the test build denies
+via FAULT_ALLOC_LIMIT. On buggy code, assert(0) fires in net_server_socket_reader.
+On fixed code, the connection is dropped gracefully and the proxy survives.
+"""
+
+import os
+import socket
+import sys
+import time
+import requests
+
+HOST = os.environ.get("TELEPROXY_HOST", "teleproxy")
+PORT = int(os.environ.get("TELEPROXY_PORT", "8443"))
+STATS_PORT = int(os.environ.get("TELEPROXY_STATS_PORT", "8888"))
+STATS_URL = f"http://{HOST}:{STATS_PORT}/stats"
+
+# Partial connections to fill the buffer chunk
+PARTIAL_CONNS = int(os.environ.get("PARTIAL_CONNS", "950"))
+# Bytes to send per partial connection (< 64 for incomplete obfs2 header)
+PARTIAL_BYTES = int(os.environ.get("PARTIAL_BYTES", "10"))
+# Burst connections after filling the chunk (to trigger replacement alloc failure)
+BURST_CONNS = int(os.environ.get("BURST_CONNS", "50"))
+
+
+def check_alive(label="", show_buffers=False):
+    """Check that teleproxy stats endpoint responds."""
+    tag = f" ({label})" if label else ""
+    try:
+        r = requests.get(STATS_URL, timeout=5)
+        if r.status_code == 200:
+            if show_buffers:
+                for line in r.text.splitlines():
+                    if "buffer" in line.lower():
+                        print(f"    {line.strip()}")
+            print(f"  ALIVE{tag}: stats endpoint OK")
+            return True
+        print(f"  DEAD{tag}: stats returned {r.status_code}")
+        return False
+    except Exception as e:
+        print(f"  DEAD{tag}: {e}")
+        return False
+
+
+def main():
+    passed = 0
+    failed = 0
+
+    def check(name, condition, detail=""):
+        nonlocal passed, failed
+        if condition:
+            passed += 1
+            print(f"  PASS  {name}")
+        else:
+            failed += 1
+            print(f"  FAIL  {name}  {detail}")
+
+    target = socket.gethostbyname(HOST)
+
+    # Step 1: Baseline
+    print("Step 1: Baseline health check")
+    check("baseline_alive", check_alive("baseline"))
+    if failed:
+        print("Proxy not alive at baseline, aborting")
+        sys.exit(1)
+
+    # Step 2: Fill the buffer chunk with partial connections.
+    # Each sends < 64 bytes, so the proxy buffers the partial obfs2 header
+    # in c->in, holding a 2KB buffer indefinitely until the connection closes.
+    print(f"\nStep 2: Opening {PARTIAL_CONNS} partial connections "
+          f"(each sends {PARTIAL_BYTES} bytes)")
+    partial_sockets = []
+    partial_data = os.urandom(PARTIAL_BYTES)
+    for i in range(PARTIAL_CONNS):
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(5)
+            s.connect((target, PORT))
+            s.sendall(partial_data)
+            partial_sockets.append(s)
+        except OSError:
+            pass
+        if (i + 1) % 200 == 0:
+            print(f"  Opened {i + 1}/{PARTIAL_CONNS}...")
+
+    opened = len(partial_sockets)
+    print(f"  Opened {opened}/{PARTIAL_CONNS} partial connections")
+
+    # Brief pause for the proxy to process all the partial reads
+    time.sleep(2)
+
+    # Step 3: Verify proxy is still alive with the chunk nearly full
+    print("\nStep 3: Mid-fill health check")
+    mid_alive = check_alive("mid-fill", show_buffers=True)
+    if not mid_alive:
+        print("Proxy died during partial fill (unexpected)")
+        for s in partial_sockets:
+            try:
+                s.close()
+            except OSError:
+                pass
+        check("survived_partial_fill", False, "died before burst")
+        print(f"\nResults: {passed} passed, {failed} failed")
+        sys.exit(1 if failed else 0)
+
+    # Step 4: Burst connections to trigger the allocation failure.
+    # The buffer chunk is now full. New connections cause readv() which
+    # consumes recv buffers. The replacement allocation needs a new chunk,
+    # which is denied by FAULT_ALLOC_LIMIT → alloc_msg_buffer returns NULL.
+    # On buggy code: assert(0) fires → SIGABRT → proxy dies.
+    # On fixed code: connection dropped gracefully → proxy survives.
+    print(f"\nStep 4: Burst {BURST_CONNS} connections to trigger alloc failure")
+    burst_data = os.urandom(4096)
+    for i in range(BURST_CONNS):
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(3)
+            s.connect((target, PORT))
+            s.sendall(burst_data)
+            s.close()
+        except OSError:
+            pass
+
+    # Brief pause for crash to manifest
+    time.sleep(3)
+
+    # Step 5: Final health check — did the proxy survive?
+    print("\nStep 5: Post-burst health check")
+    alive = False
+    for attempt in range(5):
+        if check_alive(f"post-burst attempt {attempt + 1}"):
+            alive = True
+            break
+        time.sleep(1)
+
+    check("survived_alloc_failure", alive,
+          "proxy crashed on buffer allocation failure (assert in "
+          "net_server_socket_reader or rwm_process_encrypt_decrypt)")
+
+    # Step 6: Clean up partial connections
+    print("\nStep 6: Closing partial connections")
+    for s in partial_sockets:
+        try:
+            s.close()
+        except OSError:
+            pass
+    print(f"  Closed {opened} partial connections")
+
+    # Step 7: Verify proxy still works after cleanup
+    if alive:
+        time.sleep(1)
+        print("\nStep 7: Post-cleanup health check")
+        check("alive_after_cleanup", check_alive("post-cleanup"))
+
+    print(f"\nResults: {passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #54.

When `alloc_msg_buffer()` returns NULL under memory pressure (~135K concurrent connections on DD instances), three `assert()` calls in the network data path kill the entire process with SIGABRT. This replaces those fatal asserts with graceful connection teardown — dropping the individual connection instead of crashing the whole proxy.

## Changes

**net-connections.c** — `net_server_socket_reader`: recv buffer replacement failure drops the connection and resets the buffer pool instead of `assert(0)`. `prealloc_tcp_buffers` breaks on partial failure instead of `exit(2)`.

**net-msg.c** — `rwm_process_encrypt_decrypt`: returns -1 on alloc failure (propagated by `rwm_process_ex`). `rwm_encrypt_decrypt_to`: returns -1 with state rollback.

**net-tcp-connections.c** — all 4 encrypt/decrypt functions check return value and call `fail_connection()`. Upstream callers (`cpu_tcp_server_reader`, `cpu_tcp_server_writer`) propagate errors.

**net-tcp-drs.c** — DRS encrypt variant gets the same check.

**net-tcp-rpc-ext-server.c** — post-handshake decrypt check.

**net-http-server.c, mtproto-proxy-http.c** — HTTP stats/error response handlers return -1 instead of asserting on `rwm_push_data` failure.

## Test

E2E test (`make test-junk`) uses compile-time fault injection (`FAULT_ALLOC_LIMIT`) to limit buffer chunk allocations. 1910 partial connections fill the buffer pool, triggering the alloc failure path. On the old code the proxy crashes; on the new code it drops connections gracefully and stays up.

Based on analysis from #54 by @kavore — the core problem identification and crash-site analysis were correct. This PR narrows the scope to allocation-failure paths only, leaving internal invariant asserts intact.