### PR TITLE
Document SOCKS5 from Docker container to host-local proxy

### DIFF
--- a/docs/features/socks5.md
+++ b/docs/features/socks5.md
@@ -44,6 +44,60 @@ socks5 = "socks5://proxy.example.com:1080"
 ./teleproxy --direct --socks5 socks5://user:pass@proxy.example.com:1080 -H 443 -S <secret> ...
 ```
 
+## Connecting to a SOCKS5 proxy on the Docker host
+
+Two pieces have to line up when the SOCKS5 proxy runs on the same machine as the
+container:
+
+**1. Resolve the host from inside the container.**
+
+`127.0.0.1` inside a bridge-network container points at the container itself,
+not the host. Use `host.docker.internal`:
+
+| Platform | Setup |
+|----------|-------|
+| Docker Desktop (macOS, Windows) | Wired up automatically, no flags needed |
+| Linux | Pass `--add-host=host.docker.internal:host-gateway` |
+
+**2. Bind the SOCKS5 daemon to a non-loopback address.**
+
+A daemon bound only to `127.0.0.1` is unreachable from any container on a
+bridge network, regardless of `host.docker.internal`. Bind it to `0.0.0.0`
+(or to the docker bridge IP, e.g. `172.17.0.1`):
+
+```bash
+# Won't work — only listens on host loopback
+ssh -D 127.0.0.1:1080 user@hop.example.com
+
+# Works — reachable from containers
+ssh -D 0.0.0.0:1080 user@hop.example.com
+```
+
+The same applies to dante, gost, 3proxy, sing-box, and any other SOCKS5 server.
+Check the listen address with `ss -ltnp | grep 1080`.
+
+**Verify before launching teleproxy:**
+
+```bash
+docker run --rm --add-host=host.docker.internal:host-gateway alpine \
+  sh -c 'apk add -q curl && curl -sS --socks5 host.docker.internal:1080 https://api.telegram.org'
+```
+
+If that prints the Telegram API banner, teleproxy will work too:
+
+```bash
+docker run -d \
+  --name teleproxy \
+  -p 443:443 \
+  --add-host=host.docker.internal:host-gateway \
+  -e SOCKS5_PROXY=socks5://host.docker.internal:1080 \
+  -e DIRECT_MODE=true \
+  ghcr.io/teleproxy/teleproxy:latest
+```
+
+`--network host` is the simplest fallback when the host port is free, but it is
+not required.
+
 ## URL format
 
 Two schemes are supported:

--- a/docs/features/socks5.ru.md
+++ b/docs/features/socks5.ru.md
@@ -44,6 +44,60 @@ socks5 = "socks5://proxy.example.com:1080"
 ./teleproxy --direct --socks5 socks5://user:pass@proxy.example.com:1080 -H 443 -S <secret> ...
 ```
 
+## Подключение к SOCKS5-прокси на хосте Docker
+
+Когда SOCKS5-прокси работает на той же машине, что и контейнер, нужно совпадение
+двух условий:
+
+**1. Резолв хоста изнутри контейнера.**
+
+`127.0.0.1` внутри контейнера в bridge-сети указывает на сам контейнер, а не на
+хост. Используйте `host.docker.internal`:
+
+| Платформа | Настройка |
+|-----------|-----------|
+| Docker Desktop (macOS, Windows) | Работает из коробки, флаги не нужны |
+| Linux | Передайте `--add-host=host.docker.internal:host-gateway` |
+
+**2. SOCKS5-демон должен слушать не только loopback.**
+
+Демон, привязанный только к `127.0.0.1`, недоступен из любого контейнера в
+bridge-сети, какой бы ни был `host.docker.internal`. Привяжите его к `0.0.0.0`
+(или к IP docker-моста, например `172.17.0.1`):
+
+```bash
+# Не работает — слушает только loopback хоста
+ssh -D 127.0.0.1:1080 user@hop.example.com
+
+# Работает — доступен из контейнеров
+ssh -D 0.0.0.0:1080 user@hop.example.com
+```
+
+То же касается dante, gost, 3proxy, sing-box и любого другого SOCKS5-сервера.
+Адрес прослушивания можно проверить через `ss -ltnp | grep 1080`.
+
+**Проверьте до запуска teleproxy:**
+
+```bash
+docker run --rm --add-host=host.docker.internal:host-gateway alpine \
+  sh -c 'apk add -q curl && curl -sS --socks5 host.docker.internal:1080 https://api.telegram.org'
+```
+
+Если выводится баннер Telegram API, teleproxy тоже заработает:
+
+```bash
+docker run -d \
+  --name teleproxy \
+  -p 443:443 \
+  --add-host=host.docker.internal:host-gateway \
+  -e SOCKS5_PROXY=socks5://host.docker.internal:1080 \
+  -e DIRECT_MODE=true \
+  ghcr.io/teleproxy/teleproxy:latest
+```
+
+`--network host` — самый простой вариант, когда порт на хосте свободен, но он
+не обязателен.
+
 ## Формат URL
 
 Поддерживаются две схемы:


### PR DESCRIPTION
Adds a "Connecting to a SOCKS5 proxy on the Docker host" section to the SOCKS5 docs page (en + ru). Covers the two operational gotchas behind #65:

1. `host.docker.internal` resolution — automatic on Docker Desktop, needs `--add-host=host.docker.internal:host-gateway` on Linux.
2. The SOCKS5 daemon must bind to a non-loopback address (`0.0.0.0` or the docker bridge IP), not just `127.0.0.1`. This is the part that usually trips people up.

Includes a `curl --socks5` one-liner to verify reachability from a throwaway container before launching teleproxy.

Closes #65.