### PR TITLE
Allow config download via outbound proxy (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+- New `CONFIG_DOWNLOAD_PROXY` env var routes the `proxy-multi.conf` download
+  through an outbound HTTP/SOCKS proxy (#61). Useful when `core.telegram.org`
+  is unreachable directly from the host. Defaults to `SOCKS5_PROXY` when
+  unset, so a single knob can cover both DC routing and config refresh.
+
 ## [4.12.2]
 
 Build hygiene. No runtime changes.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,10 @@ description: "Release history for Teleproxy. Version details, new features, bug 
 
 # Changelog
 
+## Unreleased
+
+- **`CONFIG_DOWNLOAD_PROXY` env var for the proxy-multi.conf download** ([#61](https://github.com/teleproxy/teleproxy/issues/61)). Hosts that can't reach `core.telegram.org` directly can now route the config refresh through an outbound HTTP or SOCKS proxy. Accepts any URL `curl -x` understands (`http://`, `https://`, `socks5://`, `socks5h://`, with optional `user:pass@`). Falls back to `SOCKS5_PROXY` when unset, so users who already proxy DC traffic don't need to set anything new. Applies to the initial fetch in `start.sh` and the 6-hour cron refresh.
+
 ## 4.12.2
 
 Build hygiene release. No runtime changes.

--- a/docs/docker/configuration.md
+++ b/docs/docker/configuration.md
@@ -28,6 +28,7 @@ description: "Complete reference for Teleproxy Docker environment variables: sec
 | `IP_ALLOWLIST` | — | Path to CIDR allowlist file |
 | `STATS_ALLOW_NET` | — | Comma-separated CIDR ranges to allow stats access from (e.g. `100.64.0.0/10,fd00::/8`) |
 | `SOCKS5_PROXY` | — | Route upstream DC connections through a SOCKS5 proxy (`socks5://[user:pass@]host:port`) |
+| `CONFIG_DOWNLOAD_PROXY` | `$SOCKS5_PROXY` | Outbound proxy for fetching `proxy-multi.conf` from `core.telegram.org`. Accepts any URL `curl -x` understands (`http://`, `https://`, `socks5://`, `socks5h://`). Defaults to `SOCKS5_PROXY` if unset |
 | `PROXY_PROTOCOL` | false | Enable PROXY protocol v1/v2 on client listeners (for HAProxy/nginx/NLB) |
 | `DC_OVERRIDE` | — | Comma-separated DC address overrides for direct mode (e.g. `2:1.2.3.4:443,2:5.6.7.8:443`) |
 | `MAX_CONNECTIONS` | 10000 | Maximum file descriptors (≈ connections) per worker. Raise on high-memory servers, lower on constrained ones. Hard limit: 65536 |
@@ -76,6 +77,14 @@ If `core.telegram.org` is unreachable, the container uses the cached config from
 ## Automatic Config Refresh
 
 A cron job refreshes the Telegram DC configuration every 6 hours. It downloads the latest config, validates it, compares it with the existing one, and hot-reloads the proxy via `SIGHUP` if the config changed. No configuration needed.
+
+If direct connections to `core.telegram.org` are blocked from the host, set `CONFIG_DOWNLOAD_PROXY` to route the download through an outbound proxy:
+
+```bash
+docker run -d -e CONFIG_DOWNLOAD_PROXY=socks5://10.0.0.1:1080 ... ghcr.io/teleproxy/teleproxy:latest
+```
+
+When unset, falls back to `SOCKS5_PROXY` if that's configured for upstream DC routing.
 
 ## Health Check
 

--- a/start.sh
+++ b/start.sh
@@ -38,9 +38,20 @@ if [ "$DIRECT_MODE" != "true" ]; then
     fi
 
     PROXY_CONFIG_URL=${PROXY_CONFIG_URL:-https://core.telegram.org/getProxyConfig}
+    # Download via outbound proxy when core.telegram.org is unreachable directly.
+    # Falls back to SOCKS5_PROXY (the DC-routing proxy) so a single knob covers both.
+    CONFIG_DOWNLOAD_PROXY=${CONFIG_DOWNLOAD_PROXY:-${SOCKS5_PROXY:-}}
+    _proxy_arg=""
+    if [ -n "$CONFIG_DOWNLOAD_PROXY" ]; then
+        _proxy_arg="-x $CONFIG_DOWNLOAD_PROXY"
+    fi
     if [ "$NEEDS_DOWNLOAD" -eq 1 ]; then
-        echo "Downloading proxy config from $PROXY_CONFIG_URL..."
-        if curl --connect-timeout 10 --max-time 30 --retry 3 --retry-delay 2 -fsSL "$PROXY_CONFIG_URL" -o "$CONFIG_PATH.tmp"; then
+        if [ -n "$_proxy_arg" ]; then
+            echo "Downloading proxy config from $PROXY_CONFIG_URL via $CONFIG_DOWNLOAD_PROXY..."
+        else
+            echo "Downloading proxy config from $PROXY_CONFIG_URL..."
+        fi
+        if curl --connect-timeout 10 --max-time 30 --retry 3 --retry-delay 2 -fsSL $_proxy_arg "$PROXY_CONFIG_URL" -o "$CONFIG_PATH.tmp"; then
             mv "$CONFIG_PATH.tmp" "$CONFIG_PATH"
             echo "Proxy config downloaded successfully."
         else

--- a/teleproxy-config-refresh.sh
+++ b/teleproxy-config-refresh.sh
@@ -6,9 +6,14 @@
 T_CONF=/opt/teleproxy/data/proxy-multi.conf
 T_CONF_DOWNLOAD=/opt/teleproxy/data/proxy-multi.conf-downloaded
 PROXY_CONFIG_URL=${PROXY_CONFIG_URL:-https://core.telegram.org/getProxyConfig}
+CONFIG_DOWNLOAD_PROXY=${CONFIG_DOWNLOAD_PROXY:-${SOCKS5_PROXY:-}}
+_proxy_arg=""
+if [ -n "$CONFIG_DOWNLOAD_PROXY" ]; then
+  _proxy_arg="-x $CONFIG_DOWNLOAD_PROXY"
+fi
 
 # Download latest config
-curl -s --max-time 60 "$PROXY_CONFIG_URL" -o "$T_CONF_DOWNLOAD"
+curl -s --max-time 60 $_proxy_arg "$PROXY_CONFIG_URL" -o "$T_CONF_DOWNLOAD"
 
 if [ ! -f "$T_CONF_DOWNLOAD" ]; then
   echo "Failed to download proxy configuration file to ${T_CONF_DOWNLOAD}!"


### PR DESCRIPTION
Hosts behind a censored network can't reach core.telegram.org directly to refresh proxy-multi.conf. Adds CONFIG_DOWNLOAD_PROXY env var, forwarded to curl -x in start.sh and the 6-hour cron refresh script. Accepts anything curl understands (http, https, socks5, socks5h, with optional user:pass@). Falls back to SOCKS5_PROXY when unset.

Closes #61.