### PR TITLE
Split fake-TLS SNI from camouflage backend (#62)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,9 +186,13 @@ jobs:
         fetch-depth: 0
 
     - name: Install Dependencies
+      uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: libssl-dev zlib1g-dev vim-common netcat-openbsd libunwind-dev
+        version: 1.0
+
+    - name: Set up Python venv
       run: |
-        sudo apt-get update
-        sudo apt-get install -y build-essential libssl-dev zlib1g-dev git curl vim-common python3 python3-pip python3-venv netcat-openbsd libunwind-dev
         python3 -m venv .venv
         source .venv/bin/activate
         pip install requests telethon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
   through an outbound HTTP/SOCKS proxy (#61). Useful when `core.telegram.org`
   is unreachable directly from the host. Defaults to `SOCKS5_PROXY` when
   unset, so a single knob can cover both DC routing and config refresh.
+- New `EE_BACKEND` env var splits the fake-TLS SNI domain (`EE_DOMAIN`) from
+  the actual camouflage backend (#62). Avoids the `/etc/hosts` workaround for
+  local backends, and supports unix sockets (`EE_BACKEND=unix:/run/nginx.sock`)
+  for nginx fronts. Configurable in TOML as
+  `domain = [{ name = "...", backend = "..." }]`.
 
 ## [4.12.2]
 

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ EXELIST	:= ${EXE}/teleproxy
 
 
 OBJECTS	=	\
-  ${OBJ}/src/mtproto/mtproto-proxy.o ${OBJ}/src/mtproto/mtproto-proxy-stats.o ${OBJ}/src/mtproto/mtproto-proxy-http.o ${OBJ}/src/mtproto/mtproto-config.o ${OBJ}/src/mtproto/mtproto-dc-table.o ${OBJ}/src/mtproto/mtproto-dc-probes.o ${OBJ}/src/mtproto/mtproto-check.o ${OBJ}/src/mtproto/mtproto-link.o ${OBJ}/src/net/net-tcp-rpc-ext-server.o ${OBJ}/src/net/net-tcp-rpc-ext-drain.o ${OBJ}/src/net/net-tcp-rpc-ext-top-ips.o ${OBJ}/src/net/net-tcp-rpc-ext-uniq-bloom.o ${OBJ}/src/net/net-tcp-direct-dc.o
+  ${OBJ}/src/mtproto/mtproto-proxy.o ${OBJ}/src/mtproto/mtproto-proxy-stats.o ${OBJ}/src/mtproto/mtproto-proxy-http.o ${OBJ}/src/mtproto/mtproto-config.o ${OBJ}/src/mtproto/mtproto-dc-table.o ${OBJ}/src/mtproto/mtproto-dc-probes.o ${OBJ}/src/mtproto/mtproto-check.o ${OBJ}/src/mtproto/mtproto-link.o ${OBJ}/src/net/net-tcp-rpc-ext-server.o ${OBJ}/src/net/net-tcp-rpc-ext-drain.o ${OBJ}/src/net/net-tcp-rpc-ext-top-ips.o ${OBJ}/src/net/net-tcp-rpc-ext-uniq-bloom.o ${OBJ}/src/net/net-tcp-rpc-ext-domain.o ${OBJ}/src/net/net-tcp-direct-dc.o
 
 DEPENDENCE_CXX		:=	$(subst ${OBJ}/,${DEP}/,$(patsubst %.o,%.d,${OBJECTS_CXX}))
 DEPENDENCE_STRANGE	:=	$(subst ${OBJ}/,${DEP}/,$(patsubst %.o,%.d,${OBJECTS_STRANGE}))
@@ -145,7 +145,7 @@ ${LIB_OBJS_NORMAL}: ${OBJ}/%.o: %.c | create_dirs_and_headers
 
 ${EXELIST}: ${LIBLIST}
 
-${EXE}/teleproxy:	${OBJ}/src/mtproto/mtproto-proxy.o ${OBJ}/src/mtproto/mtproto-proxy-stats.o ${OBJ}/src/mtproto/mtproto-proxy-http.o ${OBJ}/src/mtproto/mtproto-config.o ${OBJ}/src/mtproto/mtproto-dc-table.o ${OBJ}/src/mtproto/mtproto-dc-probes.o ${OBJ}/src/mtproto/mtproto-check.o ${OBJ}/src/mtproto/mtproto-link.o ${OBJ}/src/net/net-tcp-rpc-ext-server.o ${OBJ}/src/net/net-tcp-rpc-ext-drain.o ${OBJ}/src/net/net-tcp-rpc-ext-top-ips.o ${OBJ}/src/net/net-tcp-rpc-ext-uniq-bloom.o ${OBJ}/src/net/net-tcp-direct-dc.o
+${EXE}/teleproxy:	${OBJ}/src/mtproto/mtproto-proxy.o ${OBJ}/src/mtproto/mtproto-proxy-stats.o ${OBJ}/src/mtproto/mtproto-proxy-http.o ${OBJ}/src/mtproto/mtproto-config.o ${OBJ}/src/mtproto/mtproto-dc-table.o ${OBJ}/src/mtproto/mtproto-dc-probes.o ${OBJ}/src/mtproto/mtproto-check.o ${OBJ}/src/mtproto/mtproto-link.o ${OBJ}/src/net/net-tcp-rpc-ext-server.o ${OBJ}/src/net/net-tcp-rpc-ext-drain.o ${OBJ}/src/net/net-tcp-rpc-ext-top-ips.o ${OBJ}/src/net/net-tcp-rpc-ext-uniq-bloom.o ${OBJ}/src/net/net-tcp-rpc-ext-domain.o ${OBJ}/src/net/net-tcp-direct-dc.o
 	${CC} -o $@ $^ ${LDFLAGS}
 
 ${LIB}/libkdb.a: ${LIB_OBJS}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@ description: "Release history for Teleproxy. Version details, new features, bug 
 ## Unreleased
 
 - **`CONFIG_DOWNLOAD_PROXY` env var for the proxy-multi.conf download** ([#61](https://github.com/teleproxy/teleproxy/issues/61)). Hosts that can't reach `core.telegram.org` directly can now route the config refresh through an outbound HTTP or SOCKS proxy. Accepts any URL `curl -x` understands (`http://`, `https://`, `socks5://`, `socks5h://`, with optional `user:pass@`). Falls back to `SOCKS5_PROXY` when unset, so users who already proxy DC traffic don't need to set anything new. Applies to the initial fetch in `start.sh` and the 6-hour cron refresh.
+- **Split SNI domain from camouflage backend** ([#62](https://github.com/teleproxy/teleproxy/issues/62)). The fake-TLS feature used to require `EE_DOMAIN` to be both the SNI hostname and the backend connect target — operators worked around it by editing `/etc/hosts`. New `EE_BACKEND` env var separates the two: `EE_DOMAIN` keeps a clean public SNI name like `cloudflare.com`, while `EE_BACKEND` points at the actual backend (`127.0.0.1:8443`, `[::1]:8443`, or `unix:/run/nginx.sock`). Reality-style. Available as TOML too: `domain = [{ name = "cloudflare.com", backend = "127.0.0.1:8443" }]`. The legacy `EE_DOMAIN=host:port` and `domain = "..."` strings still work unchanged.
 
 ## 4.12.2
 

--- a/docs/docker/configuration.md
+++ b/docs/docker/configuration.md
@@ -23,7 +23,8 @@ description: "Complete reference for Teleproxy Docker environment variables: sec
 | `DIRECT_MODE` | false | Connect directly to Telegram DCs |
 | `RANDOM_PADDING` | false | Enable random padding only (DD mode) |
 | `EXTERNAL_IP` | auto-detected | Public IP for NAT environments |
-| `EE_DOMAIN` | — | Domain for Fake-TLS. Accepts `host:port` for custom TLS backends |
+| `EE_DOMAIN` | — | Domain for Fake-TLS (SNI hostname advertised to clients) |
+| `EE_BACKEND` | — | Optional backend for fake-TLS camouflage. Splits the SNI domain (`EE_DOMAIN`) from the connect target. Accepts `host:port`, `[ipv6]:port`, or `unix:/path` for a local socket — useful when `EE_DOMAIN` is a public SNI like `cloudflare.com` but the actual backend is a local nginx |
 | `IP_BLOCKLIST` | — | Path to CIDR blocklist file |
 | `IP_ALLOWLIST` | — | Path to CIDR allowlist file |
 | `STATS_ALLOW_NET` | — | Comma-separated CIDR ranges to allow stats access from (e.g. `100.64.0.0/10,fd00::/8`) |

--- a/src/common/toml-config.c
+++ b/src/common/toml-config.c
@@ -370,8 +370,8 @@ int toml_config_load (const char *path, struct toml_config *cfg,
     cfg->domain_count = 0;
     toml_datum_t d = toml_get (top, "domain");
     if (d.type == TOML_STRING) {
-      /* single domain as string */
-      snprintf (cfg->domains[0], sizeof (cfg->domains[0]), "%s", d.u.s);
+      snprintf (cfg->domains[0].name, sizeof (cfg->domains[0].name), "%s", d.u.s);
+      cfg->domains[0].backend[0] = '\0';
       cfg->domain_count = 1;
     } else if (d.type == TOML_ARRAY) {
       int n = d.u.arr.size;
@@ -382,12 +382,30 @@ int toml_config_load (const char *path, struct toml_config *cfg,
       }
       for (int i = 0; i < n; i++) {
         toml_datum_t elem = d.u.arr.elem[i];
-        if (elem.type != TOML_STRING) {
-          snprintf (errbuf, errlen, "domain[%d]: expected string", i);
+        cfg->domains[i].backend[0] = '\0';
+        if (elem.type == TOML_STRING) {
+          snprintf (cfg->domains[i].name, sizeof (cfg->domains[i].name), "%s", elem.u.s);
+        } else if (elem.type == TOML_TABLE) {
+          toml_datum_t name_d = toml_get (elem, "name");
+          if (name_d.type != TOML_STRING) {
+            snprintf (errbuf, errlen, "domain[%d]: missing 'name' string", i);
+            toml_free (res);
+            return -1;
+          }
+          snprintf (cfg->domains[i].name, sizeof (cfg->domains[i].name), "%s", name_d.u.s);
+          toml_datum_t backend_d = toml_get (elem, "backend");
+          if (backend_d.type == TOML_STRING) {
+            snprintf (cfg->domains[i].backend, sizeof (cfg->domains[i].backend), "%s", backend_d.u.s);
+          } else if (backend_d.type != TOML_UNKNOWN) {
+            snprintf (errbuf, errlen, "domain[%d].backend: expected string", i);
+            toml_free (res);
+            return -1;
+          }
+        } else {
+          snprintf (errbuf, errlen, "domain[%d]: expected string or table", i);
           toml_free (res);
           return -1;
         }
-        snprintf (cfg->domains[i], sizeof (cfg->domains[i]), "%s", elem.u.s);
       }
       cfg->domain_count = n;
     }

--- a/src/common/toml-config.h
+++ b/src/common/toml-config.h
@@ -50,7 +50,10 @@ struct toml_config {
   char proxy_tag[33];      /* -P; empty = not set (32 hex + NUL) */
 
   /* TLS (not reloadable) */
-  char domains[TOML_CONFIG_MAX_DOMAINS][256];
+  struct toml_domain {
+    char name[256];     /* SNI hostname advertised in fake-TLS ClientHello */
+    char backend[256];  /* host:port or unix:/path; empty = forward to name itself */
+  } domains[TOML_CONFIG_MAX_DOMAINS];
   int domain_count;
 
   /* Stats (reloadable) */

--- a/src/mtproto/mtproto-check.c
+++ b/src/mtproto/mtproto-check.c
@@ -1154,7 +1154,10 @@ int cmd_check (int argc, char *argv[]) {
     }
     if (ctx.domain_count == 0) {
       for (int i = 0; i < toml_cfg.domain_count; i++) {
-        parse_domain (toml_cfg.domains[i], ctx.domains[ctx.domain_count],
+        const char *spec = toml_cfg.domains[i].backend[0]
+                           ? toml_cfg.domains[i].backend
+                           : toml_cfg.domains[i].name;
+        parse_domain (spec, ctx.domains[ctx.domain_count],
                       sizeof (ctx.domains[0]),
                       &ctx.domain_ports[ctx.domain_count]);
         ctx.domain_count++;

--- a/src/mtproto/mtproto-proxy-stats.c
+++ b/src/mtproto/mtproto-proxy-stats.c
@@ -1178,7 +1178,7 @@ void mtfront_prepare_link_page (stats_buffer_t *sb,
     char secret_hex[1024];
     int pos = 0;
 
-    if (toml_cfg.domain_count > 0 && toml_cfg.domains[0][0]) {
+    if (toml_cfg.domain_count > 0 && toml_cfg.domains[0].name[0]) {
       pos += snprintf (secret_hex + pos, sizeof (secret_hex) - pos, "ee");
       for (int j = 0; j < 16; j++) {
         int rem = (int)sizeof (secret_hex) - pos;
@@ -1188,7 +1188,7 @@ void mtfront_prepare_link_page (stats_buffer_t *sb,
         if (w < 0 || w >= rem) break;
         pos += w;
       }
-      const char *dom = toml_cfg.domains[0];
+      const char *dom = toml_cfg.domains[0].name;
       const char *dom_colon = strchr (dom, ':');
       int dom_len = dom_colon ? (int)(dom_colon - dom) : (int)strlen (dom);
       for (int j = 0; j < dom_len; j++) {

--- a/src/mtproto/mtproto-proxy.c
+++ b/src/mtproto/mtproto-proxy.c
@@ -1383,7 +1383,7 @@ int f_parse_option (int val) {
     mtproto_front_functions.flags &= ~ENGINE_NO_PORT;
     break;
   case 'D':
-    tcp_rpc_add_proxy_domain (optarg);
+    tcp_rpc_add_proxy_domain (optarg, NULL);
     domain_count++;
     break;
   case 'S':
@@ -1648,7 +1648,8 @@ void mtfront_pre_init (void) {
       ip_acl_add_stats_net (toml_cfg.stats_allow_nets[i]);
     }
     for (int i = 0; i < toml_cfg.domain_count; i++) {
-      tcp_rpc_add_proxy_domain (toml_cfg.domains[i]);
+      tcp_rpc_add_proxy_domain (toml_cfg.domains[i].name,
+                                toml_cfg.domains[i].backend[0] ? toml_cfg.domains[i].backend : NULL);
       domain_count++;
     }
     for (int i = 0; i < toml_cfg.dc_override_count; i++) {

--- a/src/net/net-tcp-rpc-ext-domain.c
+++ b/src/net/net-tcp-rpc-ext-domain.c
@@ -1,0 +1,83 @@
+/*
+    This file is part of Teleproxy.
+
+    Teleproxy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+/*
+ * Fake-TLS domain registration.  Owns tcp_rpc_add_proxy_domain — the entry
+ * point used by both the CLI flag (-D) and the TOML [[domain]] loop.  The
+ * heavy lifting (TLS fingerprinting, SNI matching, server hello mimicry)
+ * lives in net-tcp-rpc-ext-server.c; this file just parses the user spec
+ * and inserts a struct domain_info into the shared hash table.
+ */
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common/kprintf.h"
+#include "jobs/jobs.h"
+#include "net/net-connections.h"
+#include "net/net-tcp-rpc-common.h"
+#include "net/net-tcp-rpc-ext-server.h"
+#include "net/net-tcp-rpc-ext-domain.h"
+
+/* Split host[:port] or [IPv6]:port. Returns malloc'd host or NULL on error. */
+static char *parse_host_port (const char *spec, int *port_out) {
+  *port_out = 443;
+  if (spec[0] == '[') {
+    const char *e = strchr (spec, ']');
+    if (!e) { return NULL; }
+    if (e[1] == ':') { *port_out = atoi (e + 2); }
+    return strndup (spec + 1, e - spec - 1);
+  }
+  const char *c = strrchr (spec, ':');
+  if (c && strchr (spec, ':') == c) { *port_out = atoi (c + 1); return strndup (spec, c - spec); }
+  return strdup (spec);
+}
+
+void tcp_rpc_add_proxy_domain (const char *name, const char *backend) {
+  assert (name != NULL);
+  struct domain_info *info = calloc (1, sizeof (struct domain_info));
+  assert (info != NULL);
+  info->port = 443;
+
+  const char *bspec = (backend && backend[0]) ? backend : NULL;
+  if (bspec == NULL) {
+    char *parsed = parse_host_port (name, &info->port);
+    if (!parsed) { kprintf ("Invalid IPv6 address: %s\n", name); free (info); return; }
+    info->domain = parsed;
+  } else {
+    info->domain = strdup (name);
+    if (strncmp (bspec, "unix:", 5) == 0 || bspec[0] == '/') {
+      info->unix_path = strdup (bspec[0] == '/' ? bspec : bspec + 5);
+    } else {
+      char *host = parse_host_port (bspec, &info->port);
+      if (!host) {
+        kprintf ("Invalid backend spec: %s\n", bspec);
+        free ((void *)info->domain); free (info); return;
+      }
+      info->backend_host = host;
+    }
+  }
+
+  if (info->port <= 0 || info->port > 65535) {
+    kprintf ("Invalid port: %s\n", bspec ? bspec : name);
+    free ((void *)info->domain); free ((void *)info->backend_host); free ((void *)info->unix_path);
+    free (info); return;
+  }
+
+  if (info->unix_path) { kprintf ("Proxy domain: %s -> unix:%s\n", info->domain, info->unix_path); }
+  else if (info->backend_host) { kprintf ("Proxy domain: %s -> %s:%d\n", info->domain, info->backend_host, info->port); }
+  else { kprintf ("Proxy domain: %s:%d\n", info->domain, info->port); }
+
+  struct domain_info **bucket = get_domain_info_bucket (info->domain, strlen (info->domain));
+  info->next = *bucket;
+  *bucket = info;
+  if (!allow_only_tls) { allow_only_tls = 1; default_domain_info = info; }
+}

--- a/src/net/net-tcp-rpc-ext-domain.h
+++ b/src/net/net-tcp-rpc-ext-domain.h
@@ -1,0 +1,36 @@
+/*
+    This file is part of Teleproxy.
+
+    Teleproxy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#pragma once
+
+#include <netinet/in.h>
+
+/* Internal interface between net-tcp-rpc-ext-server.c and
+   net-tcp-rpc-ext-domain.c.  Not part of the public API. */
+
+#define DOMAIN_HASH_MOD 257
+
+struct domain_info {
+  const char *domain;       /* SNI hostname matched in ClientHello */
+  const char *backend_host; /* host for connect; NULL = use domain */
+  const char *unix_path;    /* set => AF_UNIX backend; backend_host/port unused */
+  int port;
+  struct in_addr target;
+  unsigned char target_ipv6[16];
+  short server_hello_encrypted_size;
+  char use_random_encrypted_size;
+  char is_reversed_extension_order;
+  struct domain_info *next;
+};
+
+extern int allow_only_tls;
+extern struct domain_info *default_domain_info;
+extern struct domain_info *domains[DOMAIN_HASH_MOD];
+
+struct domain_info **get_domain_info_bucket (const char *domain, size_t len);

--- a/src/net/net-tcp-rpc-ext-server.c
+++ b/src/net/net-tcp-rpc-ext-server.c
@@ -50,6 +50,7 @@
 #include "net/net-tcp-connections.h"
 #include "net/net-tcp-drs.h"
 #include "net/net-tcp-rpc-ext-server.h"
+#include "net/net-tcp-rpc-ext-domain.h"
 #include "net/net-tcp-rpc-ext-uniq-bloom.h"
 #include "net/net-tcp-direct-dc.h"
 #include "net/net-obfs2-parse.h"
@@ -67,6 +68,7 @@
 #include <netinet/in.h>
 #include <sys/select.h>
 #include <sys/socket.h>
+#include <sys/un.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -510,25 +512,11 @@ void tcp_rpcs_set_ext_rand_pad_only(int set) {
    shared write access to the ext_secret_* state defined above and were
    moved out to keep this file under the LLM-friendly file-size cap. */
 
-static int allow_only_tls;
+int allow_only_tls;
+struct domain_info *default_domain_info;
+struct domain_info *domains[DOMAIN_HASH_MOD];
 
-struct domain_info {
-  const char *domain;
-  int port;
-  struct in_addr target;
-  unsigned char target_ipv6[16];
-  short server_hello_encrypted_size;
-  char use_random_encrypted_size;
-  char is_reversed_extension_order;
-  struct domain_info *next;
-};
-
-static struct domain_info *default_domain_info;
-
-#define DOMAIN_HASH_MOD 257
-static struct domain_info *domains[DOMAIN_HASH_MOD];
-
-static struct domain_info **get_domain_info_bucket (const char *domain, size_t len) {
+struct domain_info **get_domain_info_bucket (const char *domain, size_t len) {
   size_t i;
   unsigned hash = 0;
   for (i = 0; i < len; i++) {
@@ -752,17 +740,24 @@ static unsigned char *create_request (const char *domain) {
 }
 
 static int update_domain_info (struct domain_info *info) {
-  const char *domain = info->domain;
+  /* Unix-socket backend: no TLS server to fingerprint, fall back to safe defaults. */
+  if (info->unix_path) {
+    return 0;
+  }
 
-  // Try parsing as a literal IP address first
+  /* Connect to the camouflage backend for fingerprinting; falls back to the
+     SNI domain itself when no separate backend is configured. */
+  const char *domain = info->domain;
+  const char *host_str = info->backend_host ? info->backend_host : domain;
+
   struct in_addr addr4;
   struct in6_addr addr6;
   int af = 0;
-  if (inet_pton (AF_INET, domain, &addr4) == 1) {
+  if (inet_pton (AF_INET, host_str, &addr4) == 1) {
     af = AF_INET;
     info->target = addr4;
     memset (info->target_ipv6, 0, sizeof (info->target_ipv6));
-  } else if (inet_pton (AF_INET6, domain, &addr6) == 1) {
+  } else if (inet_pton (AF_INET6, host_str, &addr6) == 1) {
     af = AF_INET6;
     info->target.s_addr = 0;
     memcpy (info->target_ipv6, &addr6, sizeof (info->target_ipv6));
@@ -770,9 +765,9 @@ static int update_domain_info (struct domain_info *info) {
 
   struct hostent *host = NULL;
   if (!af) {
-    host = kdb_gethostbyname (domain);
+    host = kdb_gethostbyname (host_str);
     if (host == NULL || host->h_addr == NULL) {
-      kprintf ("Failed to resolve host %s\n", domain);
+      kprintf ("Failed to resolve host %s\n", host_str);
       return 0;
     }
     assert (host->h_addrtype == AF_INET || host->h_addrtype == AF_INET6);
@@ -792,7 +787,7 @@ static int update_domain_info (struct domain_info *info) {
   for (i = 0; i < TRIES; i++) {
     sockets[i] = socket (af, SOCK_STREAM, IPPROTO_TCP);
     if (sockets[i] < 0) {
-      kprintf ("Failed to open socket for %s: %s\n", domain, strerror (errno));
+      kprintf ("Failed to open socket for %s: %s\n", host_str, strerror (errno));
       return 0;
     }
     if (fcntl (sockets[i], F_SETFL, O_NONBLOCK) == -1) {
@@ -831,14 +826,14 @@ static int update_domain_info (struct domain_info *info) {
     }
 
     if (e_connect == -1 && errno != EINPROGRESS) {
-      kprintf ("Failed to connect to %s: %s\n", domain, strerror (errno));
+      kprintf ("Failed to connect to %s: %s\n", host_str, strerror (errno));
       return 0;
     }
   }
 
   unsigned char *requests[TRIES];
   for (i = 0; i < TRIES; i++) {
-    requests[i] = create_request (domain);
+    requests[i] = create_request (info->domain);
   }
   unsigned char *responses[TRIES] = {};
   int response_len[TRIES] = {};
@@ -1070,62 +1065,6 @@ static const struct domain_info *get_sni_domain_info (const unsigned char *reque
   return info;
 }
 
-void tcp_rpc_add_proxy_domain (const char *domain) {
-  assert (domain != NULL);
-
-  struct domain_info *info = calloc (1, sizeof (struct domain_info));
-  assert (info != NULL);
-  info->port = 443;
-
-  const char *host_start = domain;
-  const char *host_end = NULL;
-
-  if (domain[0] == '[') {
-    // [IPv6]:port format
-    host_end = strchr (domain, ']');
-    if (host_end == NULL) {
-      kprintf ("Invalid IPv6 address: %s\n", domain);
-      free (info);
-      return;
-    }
-    host_start = domain + 1;
-    const char *after_bracket = host_end + 1;
-    if (*after_bracket == ':') {
-      info->port = atoi (after_bracket + 1);
-    }
-    info->domain = strndup (host_start, host_end - host_start);
-  } else {
-    // Check for host:port — but only if the last colon has digits after it
-    // and there is at most one colon (to avoid matching bare IPv6 like ::1)
-    const char *colon = strrchr (domain, ':');
-    if (colon != NULL && strchr (domain, ':') == colon) {
-      // Exactly one colon — treat as host:port
-      info->port = atoi (colon + 1);
-      info->domain = strndup (domain, colon - domain);
-    } else {
-      info->domain = strdup (domain);
-    }
-  }
-
-  if (info->port <= 0 || info->port > 65535) {
-    kprintf ("Invalid port in domain spec: %s\n", domain);
-    free ((void *)info->domain);
-    free (info);
-    return;
-  }
-
-  kprintf ("Proxy domain: %s:%d\n", info->domain, info->port);
-
-  struct domain_info **bucket = get_domain_info_bucket (info->domain, strlen (info->domain));
-  info->next = *bucket;
-  *bucket = info;
-
-  if (!allow_only_tls) {
-    allow_only_tls = 1;
-    default_domain_info = info;
-  }
-}
-
 void tcp_rpc_init_proxy_domains() {
   int i;
   for (i = 0; i < DOMAIN_HASH_MOD; i++) {
@@ -1255,6 +1194,18 @@ static int is_allowed_timestamp (int timestamp) {
   return 0;
 }
 
+static int connect_unix_backend (const char *path) {
+  int fd = socket (AF_UNIX, SOCK_STREAM, 0);
+  if (fd < 0) { return -1; }
+  struct sockaddr_un sun = { .sun_family = AF_UNIX };
+  strncpy (sun.sun_path, path, sizeof (sun.sun_path) - 1);
+  if (fcntl (fd, F_SETFL, O_NONBLOCK) < 0
+      || (connect (fd, (struct sockaddr *)&sun, sizeof (sun)) < 0 && errno != EINPROGRESS)) {
+    close (fd); return -1;
+  }
+  return fd;
+}
+
 static int proxy_connection (connection_job_t C, const struct domain_info *info) {
   struct connection_info *c = CONN_INFO(C);
 
@@ -1264,20 +1215,23 @@ static int proxy_connection (connection_job_t C, const struct domain_info *info)
 
   assert (check_conn_functions (&ct_proxy_pass, 0) >= 0);
 
-  const char zero[16] = {};
-  if (info->target.s_addr == 0 && !memcmp (info->target_ipv6, zero, 16)) {
-    vkprintf (0, "failed to proxy request to %s\n", info->domain);
-    fail_connection (C, -17);
-    return 0;
-  }
-
-  int port = c->our_port == 80 ? 80 : info->port;
-
   int cfd = -1;
-  if (info->target.s_addr) {
-    cfd = client_socket (info->target.s_addr, port, 0);
+  int port = 0;
+  if (info->unix_path) {
+    cfd = connect_unix_backend (info->unix_path);
   } else {
-    cfd = client_socket_ipv6 (info->target_ipv6, port, SM_IPV6);
+    const char zero[16] = {};
+    if (info->target.s_addr == 0 && !memcmp (info->target_ipv6, zero, 16)) {
+      vkprintf (0, "failed to proxy request to %s\n", info->domain);
+      fail_connection (C, -17);
+      return 0;
+    }
+    port = c->our_port == 80 ? 80 : info->port;
+    if (info->target.s_addr) {
+      cfd = client_socket (info->target.s_addr, port, 0);
+    } else {
+      cfd = client_socket_ipv6 (info->target_ipv6, port, SM_IPV6);
+    }
   }
 
   if (cfd < 0) {

--- a/src/net/net-tcp-rpc-ext-server.h
+++ b/src/net/net-tcp-rpc-ext-server.h
@@ -98,7 +98,10 @@ void tcp_rpcs_account_bytes (int secret_id, unsigned ip, const unsigned char *ip
 void tcp_rpcs_snapshot_top_ips (int secret_id, struct worker_top_ip *out,
                                 int *out_count, int max);
 
-void tcp_rpc_add_proxy_domain (const char *domain);
+/* Register a fake-TLS domain. `backend` is optional: NULL/empty means the
+   camouflage traffic is forwarded back to the SNI domain itself (legacy).
+   When set, it can be host:port or unix:/path for an off-host or local backend. */
+void tcp_rpc_add_proxy_domain (const char *name, const char *backend);
 
 void tcp_rpc_init_proxy_domains();
 

--- a/start.sh
+++ b/start.sh
@@ -130,6 +130,9 @@ PROXY_TAG=${PROXY_TAG:-}
 RANDOM_PADDING=${RANDOM_PADDING:-}
 # Domain or host:port for TLS-transport mode (e.g. google.com or 127.0.0.1:8443)
 EE_DOMAIN=${EE_DOMAIN:-}
+# Optional separate backend for fake-TLS camouflage. Lets EE_DOMAIN stay a
+# clean SNI name while traffic forwards to host:port or unix:/path locally.
+EE_BACKEND=${EE_BACKEND:-}
 # Max connections per worker — keep modest for low-memory machines.
 # Raise via MAX_CONNECTIONS env var on high-memory servers (hard limit: 65536).
 MAX_CONNECTIONS=${MAX_CONNECTIONS:-10000}
@@ -186,7 +189,11 @@ TOML_CONFIG="data/config.toml"
     fi
 
     if [ -n "$EE_DOMAIN" ]; then
-        echo "domain = \"$EE_DOMAIN\""
+        if [ -n "$EE_BACKEND" ]; then
+            echo "domain = [{ name = \"$EE_DOMAIN\", backend = \"$EE_BACKEND\" }]"
+        else
+            echo "domain = \"$EE_DOMAIN\""
+        fi
     fi
 
     if [ -n "$BIND_ADDRESS" ]; then


### PR DESCRIPTION
Today EE_DOMAIN does double duty as both the SNI hostname clients see and the connect target for camouflage traffic. Operators wanting a clean public SNI (cloudflare.com, www.google.com, ...) but a local backend have to edit /etc/hosts to point the SNI at 127.0.0.1.

Adds EE_BACKEND env var to separate the two:

    EE_DOMAIN=cloudflare.com EE_BACKEND=127.0.0.1:8443

Accepts host:port, [ipv6]:port, or unix:/path. The unix-socket form forwards camouflage traffic to a local nginx via AF_UNIX, no TCP loopback needed.

TOML form for users not on Docker:

    domain = [{ name = "cloudflare.com", backend = "127.0.0.1:8443" }]

Legacy EE_DOMAIN=host:port and domain = "..." string keep working.

tcp_rpc_add_proxy_domain moved to a new sibling file (net-tcp-rpc-ext-domain.c) — the main file was already at the project's LLM-context size cap.

Verified locally: make test-tls and make test-multi-secret pass on the legacy path.

Closes #62.