### PR TITLE
free_target: drop redundant CT null check from assert

### DIFF
--- a/src/net/net-conn-targets.c
+++ b/src/net/net-conn-targets.c
@@ -308,7 +308,7 @@ static int free_target (conn_target_job_t CTJ) {
     return -1;
   }
 
-  assert (CT && CT->type && !CT->global_refcnt);
+  assert (CT->type && !CT->global_refcnt);
   assert (!CT->conn_tree);
   if (CT->target.s_addr) {
     vkprintf (1, "Freeing unused target to %s:%d\n", inet_ntoa (CT->target), CT->port);


### PR DESCRIPTION
Follow-up to #78. After the new `!CT` early return, asserting `CT &&` again is the redundant pattern cppcheck flagged originally.