### PR TITLE
src/common/common-stats.c: improve memory handling

### DIFF
--- a/src/common/common-stats.c
+++ b/src/common/common-stats.c
@@ -190,6 +190,9 @@ int sb_register_stat_fun (stat_fun_t func) {
     }
   }
   p = malloc (sizeof (*p));
+  if (!p) {
+    return -1;
+  }
   p->func = func;
   p->next = NULL;
   if (last) {


### PR DESCRIPTION
src/common/common-stats.c:193:3: warning: If memory allocation fails, then there is a possible null pointer dereference: p [nullPointerOutOfMemory]
src/common/common-stats.c:194:3: warning: If memory allocation fails, then there is a possible null pointer dereference: p [nullPointerOutOfMemory]