### PR TITLE
improve memory allocation

### DIFF
--- a/src/common/server-functions.c
+++ b/src/common/server-functions.c
@@ -716,8 +716,14 @@ int parse_engine_options_long (int argc, char **argv) {
   }
   
   char *shortopts = malloc (total_shortopts_len + 1);
-  assert (shortopts);
+  if (!shortopts) {
+    return -1;
+  }
   struct option *longopts = malloc ((total_longopts + 1) * sizeof (struct option));
+  if (!longopts) {
+    free (shortopts);
+    return -1;
+  }
   int lpos = 0;
   int spos = 0;
 
@@ -774,6 +780,8 @@ int parse_engine_options_long (int argc, char **argv) {
       }
     }
   }
+  free (longopts);
+  free (shortopts);
   return 0;
 }
 


### PR DESCRIPTION
src/common/server-functions.c:730:7: warning: If memory allocation fails, then there is a possible null pointer dereference: longopts [nullPointerOutOfMemory]
src/common/server-functions.c:731:7: warning: If memory allocation fails, then there is a possible null pointer dereference: longopts [nullPointerOutOfMemory]
src/common/server-functions.c:732:7: warning: If memory allocation fails, then there is a possible null pointer dereference: longopts [nullPointerOutOfMemory]
src/common/server-functions.c:733:7: warning: If memory allocation fails, then there is a possible null pointer dereference: longopts [nullPointerOutOfMemory]