### PR TITLE
lint: catch cppcheck-exhaustive findings in CI

### DIFF
--- a/.cppcheck-suppressions
+++ b/.cppcheck-suppressions
@@ -39,4 +39,3 @@ invalidPrintfArgType_sint:src/net/net-events.c
 
 // Informational — not errors.
 toomanyconfigs
-normalCheckLevelMaxBranches

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,11 +9,34 @@ on:
 jobs:
   cppcheck:
     runs-on: ubuntu-latest
+    env:
+      CPPCHECK_VERSION: "2.20.0"
     steps:
     - uses: actions/checkout@v4
 
+    - name: Cache cppcheck build
+      id: cache-cppcheck
+      uses: actions/cache@v4
+      with:
+        path: /opt/cppcheck
+        key: cppcheck-${{ env.CPPCHECK_VERSION }}-ubuntu-latest
+
+    - name: Build cppcheck from source
+      if: steps.cache-cppcheck.outputs.cache-hit != 'true'
+      run: |
+        sudo apt-get update && sudo apt-get install -y build-essential cmake
+        git clone --depth 1 --branch "$CPPCHECK_VERSION" https://github.com/danmar/cppcheck.git /tmp/cppcheck
+        cmake -S /tmp/cppcheck -B /tmp/cppcheck/build \
+          -DUSE_MATCHCOMPILER=ON \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=/opt/cppcheck
+        cmake --build /tmp/cppcheck/build -j"$(nproc)"
+        cmake --install /tmp/cppcheck/build
+
     - name: Install cppcheck
-      run: sudo apt-get update && sudo apt-get install -y cppcheck
+      run: |
+        echo "/opt/cppcheck/bin" >> "$GITHUB_PATH"
+        /opt/cppcheck/bin/cppcheck --version
 
     - name: Run cppcheck
       run: make lint

--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ clean:
 
 lint:
 	cppcheck --enable=warning,portability,performance \
+	  --check-level=exhaustive \
 	  --error-exitcode=1 \
 	  --suppressions-list=.cppcheck-suppressions \
 	  --suppress=missingIncludeSystem \

--- a/src/common/server-functions.c
+++ b/src/common/server-functions.c
@@ -718,6 +718,7 @@ int parse_engine_options_long (int argc, char **argv) {
   char *shortopts = malloc (total_shortopts_len + 1);
   assert (shortopts);
   struct option *longopts = malloc ((total_longopts + 1) * sizeof (struct option));
+  assert (longopts);
   int lpos = 0;
   int spos = 0;
 

--- a/src/common/tl-parse.c
+++ b/src/common/tl-parse.c
@@ -170,6 +170,7 @@ static inline void __tl_raw_msg_fetch_lookup_raw_message (struct tl_in_state *tl
 static inline void __tl_raw_msg_fetch_mark (struct tl_in_state *tlio_in) {
   assert (!TL_IN_MARK);
   struct raw_message *T = malloc (sizeof (*T));
+  assert (T);
   rwm_clone (T, TL_IN_RAW_MSG);
   TL_IN_MARK = T;
   TL_IN_MARK_POS = TL_IN_POS;
@@ -579,6 +580,9 @@ int __tl_fetch_init (struct tl_in_state *tlio_in, void *in, void *in_extra, enum
 
 int tlf_init_raw_message (struct tl_in_state *tlio_in, struct raw_message *msg, int size, int dup) {
   struct raw_message *r = (struct raw_message *)malloc (sizeof (*r));
+  if (!r) {
+    return -1;
+  }
   if (dup == 0) {
     rwm_move (r, msg);
   } else if (dup == 1) {
@@ -798,6 +802,9 @@ int tls_init_tcp_raw_msg (struct tl_out_state *tlio_out, JOB_REF_ARG(c), long lo
   struct raw_message *d = 0;
   if (c) {
     d = (struct raw_message *)malloc (sizeof (*d));
+    if (!d) {
+      return -1;
+    }
     rwm_init (d, 0);
   }
   return __tl_store_init (tlio_out, d, c, tl_type_tcp_raw_msg, &tl_out_tcp_raw_msg_methods, (1 << 27), qid);
@@ -812,6 +819,9 @@ int tls_init_tcp_raw_msg_unaligned (struct tl_out_state *tlio_out, JOB_REF_ARG(c
   struct raw_message *d = 0;
   if (c) {
     d = (struct raw_message *)malloc (sizeof (*d));
+    if (!d) {
+      return -1;
+    }
     rwm_init (d, 0);
   }
   return __tl_store_init (tlio_out, d, c, tl_type_tcp_raw_msg, &tl_out_tcp_raw_msg_unaligned_methods, (1 << 27), qid);
@@ -823,7 +833,10 @@ int tls_init_str (struct tl_out_state *tlio_out, char *s, long long qid, int siz
 }
 
 int tls_init_raw_msg_nosend (struct tl_out_state *tlio_out) {
-  struct raw_message *d = (struct raw_message *)malloc (sizeof (*d));  
+  struct raw_message *d = (struct raw_message *)malloc (sizeof (*d));
+  if (!d) {
+    return -1;
+  }
   rwm_init (d, 0);
   return __tl_store_init (tlio_out, d, d, tl_type_raw_msg, &tl_out_raw_msg_methods_nosend, (1 << 27), 0);
 }

--- a/src/common/tl-parse.c
+++ b/src/common/tl-parse.c
@@ -104,6 +104,9 @@ struct tl_query_header *tl_query_header_dup (struct tl_query_header *h) {
   
 struct tl_query_header *tl_query_header_clone (struct tl_query_header *h_old) {
   struct tl_query_header *h = malloc (sizeof (*h));
+  if (!h) {
+    return NULL;
+  }
   memcpy (h, h_old, sizeof (*h));
   h->ref_cnt = 1;
   return h;
@@ -778,6 +781,9 @@ int tls_init_raw_msg (struct tl_out_state *tlio_out, struct process_id *pid, lon
   struct raw_message *d = 0;
   if (pid) {
     d = (struct raw_message *)malloc (sizeof (*d));
+    if (!d) {
+      return -1;
+    }
     rwm_init (d, 0);
   }
   return __tl_store_init (tlio_out, d, NULL, tl_type_raw_msg, &tl_out_raw_msg_methods, (1 << 27), qid);

--- a/src/engine/engine-rpc.c
+++ b/src/engine/engine-rpc.c
@@ -105,6 +105,7 @@ static struct tree_rpc_custom_op *rpc_custom_op_tree;
 
 void register_custom_op_cb (unsigned op, void (*func)(struct tl_in_state *tlio_in, struct query_work_params *params)) {
   struct rpc_custom_op *O = malloc (sizeof (*O));
+  assert (O);
   O->op = op;
   O->func = func;
   rpc_custom_op_tree = tree_insert_rpc_custom_op (rpc_custom_op_tree, O, lrand48 ());
@@ -147,6 +148,9 @@ void tl_default_act_free (struct tl_act_extra *extra) {
 
 struct tl_act_extra *tl_default_act_dup (struct tl_act_extra *extra) {
   struct tl_act_extra *new = malloc (extra->size);
+  if (!new) {
+    return NULL;
+  }
   memcpy (new, extra, extra->size);
   new->flags = new->flags | 3;
   return new;
@@ -162,6 +166,7 @@ static tl_query_result_fun_t *tl_query_result_functions = NULL;
 void tl_query_result_fun_set (tl_query_result_fun_t func, int query_type_id) {
   if (!tl_query_result_functions) {
     tl_query_result_functions = calloc (sizeof (void *), 16);
+    assert (tl_query_result_functions);
   }
   tl_query_result_functions[query_type_id] = func;
 }

--- a/src/engine/engine-rpc.c
+++ b/src/engine/engine-rpc.c
@@ -386,6 +386,7 @@ static int process_act_atom_subjob (job_t job, int op, struct job_thread *JT) /*
       if (res >= 0 && !IO->error) {
         //assert (TL_OUT_RAW_MSG);
         struct raw_message *raw = malloc (sizeof (*raw));
+        assert (raw);
         rwm_clone (raw, (struct raw_message *)IO->out);
         tl_out_state_free (IO);
         if (E->raw) {

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -628,6 +628,7 @@ int default_main (server_functions_t *F, int argc, char *argv[]) {
   set_signals_handlers ();
 
   engine_t *E = calloc (sizeof (*E), 1);
+  assert (E);
   engine_state = E;
 
   engine_startup (E, F);

--- a/src/jobs/jobs.c
+++ b/src/jobs/jobs.c
@@ -580,8 +580,10 @@ int create_job_class_sub (int job_class, int min_threads, int max_threads, int e
   assert (min_threads >= 0 && max_threads >= min_threads);
 
   struct job_subclass_list *L = calloc (sizeof (*L), 1);
+  assert (L);
   L->subclass_cnt = subclass_cnt;
   L->subclasses = calloc (sizeof (struct job_subclass), subclass_cnt + 2);
+  assert (L->subclasses);
   L->subclasses += 2;
   int i;
   for (i = -2; i < subclass_cnt; i++) {
@@ -1498,6 +1500,7 @@ void job_message_queue_free (job_t job) {
 
 void job_message_queue_init (job_t job) {
   struct job_message_queue *q = calloc (sizeof (*q), 1);
+  assert (q);
   q->unsorted = alloc_mp_queue_w ();
   job_message_queue_set (job, q);
 }
@@ -1515,6 +1518,7 @@ void job_message_free_default (struct job_message *M) {
 void job_message_send (JOB_REF_ARG (job), JOB_REF_ARG (src), unsigned int type, struct raw_message *raw, int dup, int payload_ints, const unsigned int *payload, unsigned int flags, void (*destroy)(struct job_message *)) {
   assert (job->j_type & JT_HAVE_MSG_QUEUE);
   struct job_message *M = malloc (sizeof (*M) + payload_ints * 4);
+  assert (M);
   M->type = type;
   M->flags = 0;
   M->src = PTR_MOVE (src);
@@ -1560,6 +1564,7 @@ void job_message_send_data (JOB_REF_ARG (job), JOB_REF_ARG (src), unsigned int t
 void job_message_send_fake (JOB_REF_ARG (job), int (*receive_message)(job_t job, struct job_message *M, void *extra), void *extra, JOB_REF_ARG (src), unsigned int type, struct raw_message *raw, int dup, int payload_ints, const unsigned int *payload, unsigned int flags, void (*destroy)(struct job_message *)) {
   assert (job->j_type & JT_HAVE_MSG_QUEUE);
   struct job_message *M = malloc (sizeof (*M) + payload_ints * 4);
+  assert (M);
   M->type = type;
   M->flags = 0;
   M->src = PTR_MOVE (src);
@@ -1679,6 +1684,7 @@ static int notify_job_receive_message (job_t NJ, struct job_message *M, void *ex
         complete_subjob (NJ, JOB_REF_PASS (M->src), JSP_PARENT_RWE);
       } else {
         struct notify_job_subscriber *S = malloc (sizeof (*S));
+        assert (S);
         S->job = PTR_MOVE (M->src);
         S->next = NULL;
         if (N->last) {

--- a/src/jobs/jobs.h
+++ b/src/jobs/jobs.h
@@ -417,6 +417,9 @@ struct job_message_payload {
 
 static inline struct job_message_payload *job_message_payload_alloc (JOB_REF_ARG (job), int message_class, int payload_ints, unsigned int *payload) {
   struct job_message_payload *P = malloc (sizeof (*P) + 4 * payload_ints);
+  if (!P) {
+    return NULL;
+  }
   P->message_class = message_class;
   P->payload_ints = payload_ints;
   P->job = PTR_MOVE (job);

--- a/src/mtproto/mtproto-proxy-http.c
+++ b/src/mtproto/mtproto-proxy-http.c
@@ -296,6 +296,7 @@ int process_http_query (struct tl_in_state *tlio_in, job_t HQJ) {
       int len = snprintf (response_buffer, 511, "HTTP/1.1 200 OK\r\nConnection: %s\r\nContent-type: text/plain\r\nPragma: no-cache\r\nCache-control: no-store\r\n%sContent-length: 0\r\n\r\n", (HTS_DATA(c)->query_flags & QF_KEEPALIVE) ? "keep-alive" : "close", HTS_DATA(c)->query_flags & QF_EXTRA_HEADERS ? mtproto_cors_http_headers : "");
       assert (len < 511);
       struct raw_message *m = calloc (sizeof (struct raw_message), 1);
+      assert (m);
       rwm_create (m, response_buffer, len);
       http_flush (c, m);
       return 0;
@@ -442,6 +443,10 @@ int hts_stats_execute (connection_job_t c, struct raw_message *msg, int op) {
   }
 
   struct raw_message *raw = calloc (sizeof (*raw), 1);
+  if (!raw) {
+    sb_release (&sb);
+    return -1;
+  }
   rwm_init (raw, 0);
   write_basic_http_header_raw (c, raw, 200, 0, sb.pos, 0, content_type);
   if (rwm_push_data (raw, sb.buff, sb.pos) != sb.pos) {
@@ -636,7 +641,8 @@ int http_send_message (JOB_REF_ARG (C), struct tl_in_state *tlio_in, int flags) 
     char response_buffer[512];
     TLS_START_UNALIGN (JOB_REF_CREATE_PASS (C)) {
       int len = TL_IN_REMAINING;
-      tl_store_raw_data (response_buffer, snprintf (response_buffer, sizeof (response_buffer) - 1, "HTTP/1.1 200 OK\r\nConnection: %s\r\nContent-type: application/octet-stream\r\nPragma: no-cache\r\nCache-control: no-store\r\n%sContent-length: %d\r\n\r\n", (D->query_flags & QF_KEEPALIVE) ? "keep-alive" : "close", D->query_flags & QF_EXTRA_HEADERS ? mtproto_cors_http_headers : "", len));
+      int header_len = snprintf (response_buffer, sizeof (response_buffer) - 1, "HTTP/1.1 200 OK\r\nConnection: %s\r\nContent-type: application/octet-stream\r\nPragma: no-cache\r\nCache-control: no-store\r\n%sContent-length: %d\r\n\r\n", (D->query_flags & QF_KEEPALIVE) ? "keep-alive" : "close", D->query_flags & QF_EXTRA_HEADERS ? mtproto_cors_http_headers : "", len);
+      tl_store_raw_data (response_buffer, header_len);
       assert (tl_copy_through (tlio_in, tlio_out, len, 1) == len);
     } TLS_END;
   }

--- a/src/net/net-connections.c
+++ b/src/net/net-connections.c
@@ -837,6 +837,7 @@ int net_server_socket_reader (socket_connection_job_t C) /* {{{ */ {
     }
 
     struct raw_message *in = malloc (sizeof (*in));
+    assert (in);
     rwm_init (in, 0);
     
     int s = tcp_recv_buffers_total_size;

--- a/src/net/net-http-server.c
+++ b/src/net/net-http-server.c
@@ -185,6 +185,9 @@ int write_http_error_raw (connection_job_t C, struct raw_message *raw, int code)
 
 int write_http_error (connection_job_t C, int code) {
   struct raw_message *raw = calloc (sizeof (*raw), 1);
+  if (!raw) {
+    return -1;
+  }
   rwm_init (raw, 0);
   int r = write_http_error_raw (C, raw, code);
   

--- a/src/net/net-msg.c
+++ b/src/net/net-msg.c
@@ -70,7 +70,7 @@ MODULE_STAT_FUNCTION
 MODULE_STAT_FUNCTION_END
 
 
-static inline struct msg_part *alloc_msg_part (void) { MODULE_STAT->rwm_total_msg_parts ++; struct msg_part *mp = (struct msg_part *) malloc (sizeof (struct msg_part)); mp->magic = MSG_PART_MAGIC; return mp; }
+static inline struct msg_part *alloc_msg_part (void) { MODULE_STAT->rwm_total_msg_parts ++; struct msg_part *mp = (struct msg_part *) malloc (sizeof (struct msg_part)); assert (mp); mp->magic = MSG_PART_MAGIC; return mp; }
 static inline void free_msg_part (struct msg_part *mp) { MODULE_STAT->rwm_total_msg_parts --; assert (mp->magic == MSG_PART_MAGIC); free (mp); }
 
 struct msg_part *new_msg_part (struct msg_part *neighbor, struct msg_buffer *X) /* {{{ */{

--- a/src/net/net-rpc-targets.c
+++ b/src/net/net-rpc-targets.c
@@ -85,6 +85,7 @@ MODULE_STAT_FUNCTION_END
 static rpc_target_job_t rpc_target_alloc (struct process_id PID) {
   assert_engine_thread ();
   rpc_target_job_t SS = calloc (sizeof (struct async_job) + sizeof (struct rpc_target_info), 1);
+  assert (SS);
   struct rpc_target_info *S = RPC_TARGET_INFO (SS);
   
   S->PID = PID;

--- a/src/net/net-tcp-direct-dc.c
+++ b/src/net/net-tcp-direct-dc.c
@@ -268,6 +268,7 @@ static int tcp_direct_relay (connection_job_t C) {
   struct connection_info *e = CONN_INFO(E);
 
   struct raw_message *r = malloc (sizeof (*r));
+  assert (r);
   rwm_move (r, &c->in);
   rwm_init (&c->in, 0);
   vkprintf (3, "direct relay %d bytes to %s:%d\n", r->total_bytes, show_remote_ip (E), e->remote_port);

--- a/src/net/net-tcp-rpc-common.c
+++ b/src/net/net-tcp-rpc-common.c
@@ -47,6 +47,7 @@ void tcp_rpc_conn_send_init (connection_job_t C, struct raw_message *raw, int fl
   Q[0] = raw->total_bytes + 12;
   Q[1] = TCP_RPC_DATA(C)->out_packet_num ++;
   struct raw_message *r = malloc (sizeof (*r));
+  assert (r);
   if (flags & 1) {
     rwm_clone (r, raw);
   } else {
@@ -72,6 +73,7 @@ void tcp_rpc_conn_send_im (JOB_REF_ARG (C), struct raw_message *raw, int flags) 
   Q[0] = raw->total_bytes + 12;
   Q[1] = TCP_RPC_DATA(C)->out_packet_num ++;
   struct raw_message *r = malloc (sizeof (*r));
+  assert (r);
   if (flags & 1) {
     rwm_clone (r, raw);
   } else {
@@ -99,6 +101,7 @@ void tcp_rpc_conn_send (JOB_REF_ARG (C), struct raw_message *raw, int flags) {
     assert (!(flags & 1));
   } else {
     r = malloc (sizeof (*r));
+    assert (r);
     if (flags & 1) {
       rwm_clone (r, raw);
     } else {

--- a/src/net/net-tcp-rpc-ext-server.c
+++ b/src/net/net-tcp-rpc-ext-server.c
@@ -1658,11 +1658,13 @@ int tcp_rpcs_compact_parse_execute (connection_job_t C) {
            is queued, producing separate TCP segments.  This defeats DPI
            that pattern-matches the full handshake in a single packet. */
         struct raw_message *m1 = calloc (sizeof (struct raw_message), 1);
+        assert (m1);
         rwm_create (m1, response_buffer, 127);              /* ServerHello record */
         mpq_push_w (c->out_queue, m1, 0);
         job_signal (JOB_REF_CREATE_PASS (C), JS_RUN);
 
         struct raw_message *m2 = calloc (sizeof (struct raw_message), 1);
+        assert (m2);
         rwm_create (m2, response_buffer + 127, response_size - 127); /* CCS + AppData */
         mpq_push_w (c->out_queue, m2, 0);
         job_signal (JOB_REF_CREATE_PASS (C), JS_RUN);

--- a/src/net/net-tcp-rpc-ext-server.c
+++ b/src/net/net-tcp-rpc-ext-server.c
@@ -147,6 +147,7 @@ int tcp_proxy_pass_parse_execute (connection_job_t C) {
   struct connection_info *e = CONN_INFO(E);
 
   struct raw_message *r = malloc (sizeof (*r));
+  assert (r);
   rwm_move (r, &c->in);
   rwm_init (&c->in, 0);
   vkprintf (3, "proxying %d bytes to %s:%d\n", r->total_bytes, show_remote_ip (E), e->remote_port);
@@ -1135,6 +1136,7 @@ static int have_client_random (unsigned char random[16]) {
 
 static void add_client_random (unsigned char random[16]) {
   struct client_random *entry = malloc (sizeof (struct client_random));
+  assert (entry);
   memcpy (entry->random, random, 16);
   entry->time = now;
   entry->next_by_time = NULL;

--- a/src/net/net-thread.c
+++ b/src/net/net-thread.c
@@ -105,6 +105,7 @@ void notification_event_job_create (void) {
 
 void notification_event_insert_conn (connection_job_t C, int type) {
   struct notification_event *ev = malloc (sizeof (*ev));
+  assert (ev);
   ev->who = job_incref (C);
   ev->type = type;
 

--- a/src/vv/vv-tree.c
+++ b/src/vv/vv-tree.c
@@ -566,12 +566,13 @@ TREE_PREFIX int SUFFIX(tree_count_,TREE_NAME) (TREE_NODE_TYPE *T) {
 
 
 TREE_PREFIX TREE_NODE_TYPE *SUFFIX (tree_alloc_, TREE_NAME) (X_TYPE x, Y_TYPE y) {
-  TREE_NODE_TYPE *T = 
+  TREE_NODE_TYPE *T =
   #ifndef TREE_MALLOC
     zmalloc0 (sizeof (*T));
   #else
     calloc (sizeof (*T), 1);
   #endif
+  assert (T);
   T->x = x;
   T->y = y;
   #ifdef TREE_PTHREAD
@@ -657,6 +658,7 @@ TREE_PREFIX TREE_NODE_TYPE *SUFFIX(get_tree_ptr_, TREE_NAME) (TREE_NODE_TYPE **T
 TREE_PREFIX void SUFFIX(free_tree_ptr_, TREE_NAME)(TREE_NODE_TYPE *T) {
   if (T && is_hazard_ptr (T, COMMON_HAZARD_PTR_NUM, COMMON_HAZARD_PTR_NUM)) {
     struct free_later *F = malloc (sizeof (*F));
+    assert (F);
     F->ptr = T;
     F->free = (void *)SUFFIX(free_tree_ptr_, TREE_NAME);
     insert_free_later_struct (F);


### PR DESCRIPTION
Bumps `make lint` to `cppcheck --check-level=exhaustive`. The default
("normal") level skips the OOM-on-malloc and cross-TU null-pointer paths
that have been showing up in one-off contributor PRs (#78, #84, #85).

Opening as draft: enabling this surfaces ~78 existing findings across
src/common, src/engine, src/jobs, src/net, src/vv, and one uninitvar in
src/mtproto. Fixes land in follow-up commits on this branch; PR moves to
ready when CI is green.