### PR TITLE
moderate: scope concurrency group per issue/discussion

### DIFF
--- a/.github/workflows/telegram-notify.yml
+++ b/.github/workflows/telegram-notify.yml
@@ -37,7 +37,7 @@ permissions:
   models: read
 
 concurrency:
-  group: telegram-notify
+  group: telegram-notify-${{ github.event.issue.number || github.event.discussion.number || github.run_id }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
The global `telegram-notify` concurrency group keeps at most one pending run; when a third event is queued, the previously pending run is cancelled silently. That happened on 2026-06-02 with a three-issue spam burst: #109 ran, #110 was queued then evicted when #111 was queued, #111 ran. #109 and #111 were both deleted by the moderator; #110 survived because its `moderate` job never executed.

Keying the group per issue/discussion number lets distinct targets moderate in parallel while comments on the same issue still serialize, which the `<!-- tg_thread_id:N -->` round-trip in the notify job relies on. `workflow_dispatch` falls through to `github.run_id` so manual re-moderation never contends with itself.

Cleanup for the surviving #110 will be a one-off `workflow_dispatch` after this merges.

The `tg-test-session` group in `test.yml` is unrelated and untouched — e2e remains serialized.