### PR TITLE
Drop dead helpers from parse-config.c

### DIFF
--- a/src/common/parse-config.c
+++ b/src/common/parse-config.c
@@ -60,19 +60,6 @@ int cfg_skspc (void) {
   return (unsigned char) *cfg_cur;
 }
 
-int cfg_getlex (void) {
-  switch (cfg_skipspc()) {
-  case ';':
-  case ':':
-  case '{':
-  case '}':
-    return cfg_lex = *cfg_cur++;
-  case 0:
-    return cfg_lex = 0;
-  }
-  return cfg_lex = -1;
-}
-
 int cfg_getword (void) {
   cfg_skspc();
   char *s = cfg_cur;
@@ -92,16 +79,6 @@ int cfg_getword (void) {
   return s - cfg_cur;
 }
 
-int cfg_getstr (void) {
-  cfg_skspc();
-  char *s = cfg_cur;
-  if (*s == '"') { return 1; } // fix later
-  while (*s > ' ' && *s != ';') {
-    s++;
-  }
-  return s - cfg_cur;
-}
-
 long long cfg_getint (void) {
   cfg_skspc ();
   char *s = cfg_cur;
@@ -111,21 +88,6 @@ long long cfg_getint (void) {
   }
   cfg_cur = s;
   return x;
-}
-
-long long cfg_getint_zero (void) {
-  cfg_skspc ();
-  char *s = cfg_cur;
-  long long x = 0;
-  while (*s >= '0' && *s <= '9') {
-    x = x * 10 + *(s ++) - '0';
-  }
-  if (cfg_cur == s) {
-    return -1;
-  } else {
-    cfg_cur = s;
-    return x;
-  }
 }
 
 long long cfg_getint_signed_zero (void) {
@@ -167,22 +129,6 @@ void syntax (const char *msg, ...) {
   fprintf (stderr, " near %.*s%s\n", len, cfg_cur, len >= 20 ? " ..." : "");
 }
 
-void syntax_warning (const char *msg, ...) {
-  va_list args;
-  if (cfg_lno) {
-    fprintf (stderr, "%s:%d: ", config_name, cfg_lno);
-  }
-  fputs ("warning: ", stderr);
-  va_start (args, msg);
-  vfprintf (stderr, msg, args);
-  va_end (args);
-  int len = 0;
-  while (cfg_cur[len] && cfg_cur[len] != 13 && cfg_cur[len] != 10 && len < 20) {
-    len++;
-  }
-  fprintf (stderr, " near %.*s%s\n", len, cfg_cur, len >= 20 ? " ..." : "");
-}
-
 int expect_lexem (int lexem) {
   if (cfg_lex != lexem) {
     syntax ("%c expected", lexem);
@@ -190,16 +136,6 @@ int expect_lexem (int lexem) {
   } else {
     return 0;
   }
-}
-
-int expect_word (const char *name, int len) {
-  int l = cfg_getword ();
-  if (len != l || memcmp (name, cfg_cur, len)) {
-    syntax ("Expected %.*s", len, name);
-    return -1;
-  }
-  cfg_cur += l;
-  return 0;
 }
 
 struct hostent *cfg_gethost_ex (int verb) {
@@ -274,21 +210,3 @@ void md5_hex_config (char *out) {
   md5_hex (config_buff, config_bytes, out);
 }
 
-void close_config (int *fd) {
-  if (config_buff) {
-    free (config_buff);
-    config_buff = NULL;
-  }
-  if (config_name) {
-    free (config_name);
-    config_name = NULL;
-  }
-  config_bytes = 0;
-  cfg_cur = cfg_start = cfg_end = NULL;
-  if (fd) {
-    if (*fd >= 0) {
-      assert (!close (*fd));
-      *fd = -1;
-    }
-  }
-}

--- a/src/common/parse-config.h
+++ b/src/common/parse-config.h
@@ -25,23 +25,16 @@ extern int config_bytes, cfg_lno, cfg_lex;
 
 int cfg_skipspc (void);
 int cfg_skspc (void);
-int cfg_getlex (void);
 int cfg_getword (void);
-int cfg_getstr (void);
 void syntax (const char *msg, ...);
-void syntax_warning (const char *msg, ...);
 int expect_lexem (int lexem);
-int expect_word (const char *name, int len);
 void reset_config (void);
 int load_config (const char *file, int fd);
-void close_config (int *fd);
 void md5_hex_config (char *out);
 struct hostent *cfg_gethost (void);
 struct hostent *cfg_gethost_ex (int verb);
 long long cfg_getint (void);
-long long cfg_getint_zero (void);
 long long cfg_getint_signed_zero (void);
 
 #define Expect(l) { int t = expect_lexem (l); if (t < 0) { return t; } }
-#define ExpectWord(s) { int t = expect_word (s, strlen (s)); if (t < 0) { return t; } }
 #define Syntax(...) { syntax (__VA_ARGS__); return -1; }


### PR DESCRIPTION
Removes 6 unreachable functions from \`src/common/parse-config.c\`, the legacy KittenDB config parser. teleproxy switched to TOML (\`src/common/toml-config.c\`); the few still-live entry points in this file (\`load_config\`, \`cfg_getword\`, \`cfg_getint\`, \`cfg_getint_signed_zero\`, \`expect_lexem\`, \`syntax\`, \`cfg_gethost*\`, \`reset_config\`, \`md5_hex_config\`, \`cfg_skipspc\`, \`cfg_skspc\`) are still used by \`src/mtproto/mtproto-config.c\`.

Deleted:
- \`cfg_getlex\`
- \`cfg_getstr\`
- \`cfg_getint_zero\`
- \`syntax_warning\`
- \`expect_word\`
- \`close_config\`

Also drops the orphaned \`ExpectWord()\` macro from \`parse-config.h\` (its only caller was \`expect_word\`). \`Expect()\` stays — \`expect_lexem\` is still used.

Verified with \`make\` (macOS native) and \`make lint\`. \`cppcheck --enable=unusedFunction\` drops from 183 to 177 with no new findings unmasked elsewhere.

Refs #106, #114.