### PR TITLE
Cleanup common/server-functions

### DIFF
--- a/src/common/server-functions.c
+++ b/src/common/server-functions.c
@@ -72,9 +72,6 @@
 
 long long max_allocated_buffer_bytes __attribute__ ((weak));
 
-int engine_options_num;
-char *engine_options[MAX_ENGINE_OPTIONS];
-
 
 int start_time;
 
@@ -531,9 +528,6 @@ int parse_one_option (int val) {
 }
 
 int parse_engine_options_long (int argc, char **argv) {
-  engine_options_num = argc;
-  memcpy ((void *)engine_options, argv, sizeof (void *) * argc);
-
   int total_longopts = 0;
   int total_shortopts_len = 0;
   int i;

--- a/src/common/server-functions.h
+++ b/src/common/server-functions.h
@@ -43,10 +43,6 @@ extern "C" {
 # define BITS_STR "32"
 #endif
 
-#define MAX_ENGINE_OPTIONS 1000
-extern int engine_options_num;
-extern char *engine_options[MAX_ENGINE_OPTIONS];
-
 int change_user_group (const char *username, const char *groupname);
 int raise_file_rlimit (int maxfiles);
 

--- a/src/common/server-functions.h
+++ b/src/common/server-functions.h
@@ -46,16 +46,11 @@ extern "C" {
 int change_user_group (const char *username, const char *groupname);
 int raise_file_rlimit (int maxfiles);
 
-int fast_backtrace (void **buffer, int size);
-
 void print_backtrace (void);
 void ksignal (int sig, void (*handler) (int));
 void set_debug_handlers (void);
 
-int adjust_oom_score (int oom_score_adj);
-
-extern int allow_core_dump;
-extern int quit_steps, start_time;
+extern int start_time;
 extern int daemonize;
 extern const char *username, *progname, *groupname;
 
@@ -80,10 +75,6 @@ struct engine_parse_option {
   int arg;
 };
 
-/* init_parse_options should be called before parse_option */
-//void init_parse_options (int keep_mask, const unsigned char *keep_options_custom_list);
-void init_parse_options (unsigned keep_mask, const unsigned *keep_options_custom_list);
-
 int parse_engine_options_long (int argc, char **argv);
 int parse_usage (void);
 void parse_option (const char *name, int arg, int *var, int val, const char *help, ...) __attribute__ ((format (printf, 5, 6)));
@@ -94,9 +85,6 @@ void parse_option_ex (const char *name, int arg, int *var, int val, unsigned fla
 long long parse_memory_limit (const char *s);
 
 void add_builtin_parse_options (void);
-
-typedef void (*extra_debug_handler_t)(void);
-extern extra_debug_handler_t extra_debug_handler;
 
 static inline void barrier (void) {  
   asm volatile("": : :"memory");


### PR DESCRIPTION
Remove 2 unused global variables and a number of function headers that have no definitions.
Tested with `make` and `make lint`

Refs #106, #114.