### PR TITLE
Drop dead helpers from common-stats.c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ fuzz/*.o
 fuzz/crash-*
 fuzz/oom-*
 fuzz/timeout-*
+build-deadcode.log
 *.dSYM/
 # Docs: ignore all markdown except shipped docs and mkdocs site
 *.md

--- a/src/common/common-stats.c
+++ b/src/common/common-stats.c
@@ -175,34 +175,6 @@ int am_get_memory_stats (am_memory_stat_t *S, int flags) {
   return 0;
 }
 
-struct stat_fun_en {
-  stat_fun_t func;
-  struct stat_fun_en *next;
-};
-struct stat_fun_en *stat_func_first = NULL;
-
-int sb_register_stat_fun (stat_fun_t func) {
-  struct stat_fun_en *last = NULL, *p;
-  for (p = stat_func_first; p; p = p->next) {
-    last = p;
-    if (p->func == func) {
-      return 0;
-    }
-  }
-  p = malloc (sizeof (*p));
-  if (!p) {
-    return -1;
-  }
-  p->func = func;
-  p->next = NULL;
-  if (last) {
-    last->next = p;
-  } else {
-    stat_func_first = p;
-  }
-  return 1;
-}
-
 /************************ stats buffer functions **********************************/
 void sb_init (stats_buffer_t *sb, char *buff, int size) {
   sb->buff = buff;
@@ -242,19 +214,11 @@ static int sb_full (stats_buffer_t *sb) {
   return (sb->pos == sb->size - 1 && sb->buff[sb->pos]) || sb->pos >= sb->size;
 }
 
+/* cppcheck-suppress unusedFunction ; called from mtfront_prepare_stats() in src/mtproto/mtproto-proxy-stats.c (cppcheck misses the cross-TU call) */
 void sb_prepare (stats_buffer_t *sb) {
   sb->pos = prepare_stats (sb->buff, sb->size);
   if (sb_full (sb)) {
     sb_truncate (sb);
-    return;
-  }
-  struct stat_fun_en *p;
-  for (p = stat_func_first; p; p = p->next) {
-    p->func (sb);
-    if (sb_full (sb)) {
-      sb_truncate (sb);
-      return;
-    }
   }
 }
 
@@ -281,6 +245,7 @@ void sb_printf (stats_buffer_t *sb, const char *format, ...) {
 }
 /************************************************************************************/
 
+/* cppcheck-suppress unusedFunction ; called from mtfront_prepare_stats() in src/mtproto/mtproto-proxy-stats.c (cppcheck misses the cross-TU call) */
 void sb_memory (stats_buffer_t *sb, int flags) {
   am_memory_stat_t S;
   if (!am_get_memory_stats (&S, flags & AM_GET_MEMORY_USAGE_SELF)) {
@@ -301,10 +266,6 @@ void sb_memory (stats_buffer_t *sb, int flags) {
   }
 }
 
-void sb_print_queries (stats_buffer_t *sb, const char *const desc, long long q) {
-  sb_printf (sb, "%s\t%lld\nqps_%s\t%.3lf\n", desc, q, desc, safe_div (q, now - start_time));
-}
-
 int sb_sum_i (void **base, int len, int offset) {
   int res = 0;
   int i;
@@ -321,25 +282,4 @@ long long sb_sum_ll (void **base, int len, int offset) {
     res += *(long long *)((base[i]) + offset);
   }
   return res;
-}
-
-double sb_sum_f (void **base, int len, int offset) {
-  double res = 0;
-  int i;
-  for (i = 0; i < len; i++) if (base[i]) {
-    res += *(double *)((base[i]) + offset);
-  }
-  return res;
-}
-
-void sbp_print_date (stats_buffer_t *sb, const char *key, time_t unix_time) {
-  struct tm b;
-  struct tm *t = gmtime_r (&unix_time, &b);
-  if (t) {
-    char s[256];
-    size_t l = strftime (s, sizeof (s), "%c", t);
-    if (l > 0) {
-      sb_printf (sb, "%s\t%s\n", key, s);
-    }
-  }
 }

--- a/src/common/common-stats.h
+++ b/src/common/common-stats.h
@@ -32,18 +32,15 @@
 
 #define SB_PRINT_I64(x) sb_printf (&sb, "%s\t%lld\n", #x, x)
 #define SB_PRINT_I32(x) sb_printf (&sb, "%s\t%d\n", #x, x)
-#define SB_PRINT_QUERIES(x) sb_print_queries (&sb, #x, x)
 #define SB_PRINT_DOUBLE(x) sb_printf (&sb, "%s\t%.6lf\n", #x, x)
 #define SB_PRINT_TIME(x) sb_printf (&sb, "%s\t%.6lfs\n", #x, x)
 #define SB_PRINT_PERCENT(x) sb_printf (&sb, "%s\t%.3lf%%\n", #x, x)
 
 #define SBP_PRINT_I32(x) sb_printf (sb, "%s\t%d\n", #x, x)
 #define SBP_PRINT_I64(x) sb_printf (sb, "%s\t%lld\n", #x, x)
-#define SBP_PRINT_QUERIES(x) sb_print_queries (sb, #x, x)
 #define SBP_PRINT_DOUBLE(x) sb_printf (sb, "%s\t%.6lf\n", #x, x)
 #define SBP_PRINT_TIME(x) sb_printf (sb, "%s\t%.6lfs\n", #x, x)
 #define SBP_PRINT_PERCENT(x) sb_printf (sb, "%s\t%.3lf%%\n", #x, x)
-#define SBP_PRINT_DATE(x) sbp_print_date (sb, #x, x)
 
 #define SBM_PRINT_I32(x) sb_printf (sb, "%s%s\t%d\n", MODULE_STAT_PREFIX_NAME ?: "", #x, x)
 #define SBM_PRINT_I64(x) sb_printf (sb, "%s%s\t%lld\n", MODULE_STAT_PREFIX_NAME ?: "", #x, x)
@@ -81,15 +78,9 @@ void sb_release (stats_buffer_t *sb);
 void sb_prepare (stats_buffer_t *sb);
 void sb_printf (stats_buffer_t *sb, const char *format, ...) __attribute__ ((format (printf, 2, 3)));
 void sb_memory (stats_buffer_t *sb, int flags);
-void sb_print_queries (stats_buffer_t *sb, const char *const desc, long long q);
-void sbp_print_date (stats_buffer_t *sb, const char *key, time_t unix_time);
-
-typedef void (*stat_fun_t) (stats_buffer_t *sb);
-int sb_register_stat_fun (stat_fun_t fun);
 
 int sb_sum_i (void **base, int len, int offset);
 long long sb_sum_ll (void **base, int len, int offset);
-double sb_sum_f (void **base, int len, int offset);
 
 #define SB_SUM_I(name) \
   sb_sum_i ((void **)MODULE_STAT_ARR, max_job_thread_id + 1, offsetof (MODULE_STAT_TYPE, name))
@@ -97,9 +88,5 @@ double sb_sum_f (void **base, int len, int offset);
 #define SB_SUM_LL(name) \
   sb_sum_ll ((void **)MODULE_STAT_ARR, max_job_thread_id + 1, offsetof (MODULE_STAT_TYPE, name))
 
-#define SB_SUM_F(name) \
-  sb_sum_f ((void **)MODULE_STAT_ARR, max_job_thread_id + 1, offsetof (MODULE_STAT_TYPE, name))
-
 #define SB_SUM_ONE_I(name) sb_printf (sb, "%s%s\t%d\n", MODULE_STAT_PREFIX_NAME ?: "", #name, SB_SUM_I(name))
 #define SB_SUM_ONE_LL(name) sb_printf (sb, "%s%s\t%lld\n", MODULE_STAT_PREFIX_NAME ?: "", #name, SB_SUM_LL(name))
-#define SB_SUM_ONE_F(name) sb_printf (sb, "%s%s\t%lf\n", MODULE_STAT_PREFIX_NAME ?: "", #name, SB_SUM_F(name))


### PR DESCRIPTION
Removes 4 unused stats helpers and their 5 transitively-dead macros from common-stats.{c,h}. Verified dead via cross-grep — `sb_print_queries`, `sb_sum_f`, `sbp_print_date` were only reachable through `SB_PRINT_QUERIES` / `SBP_PRINT_QUERIES`, `SB_SUM_F` / `SB_SUM_ONE_F`, `SBP_PRINT_DATE` macros, which are never invoked. `sb_register_stat_fun` has no caller, which also makes the supporting `stat_fun_t` typedef, `struct stat_fun_en`, and `stat_func_first` global orphans; the loop in `sb_prepare` that iterated `stat_func_first` is removed as part of the same dead-code island.

`sb_prepare` and `sb_memory` get inline `cppcheck-suppress unusedFunction` annotations — they're called from `mtfront_prepare_stats()` in `mtproto-proxy-stats.c` but cppcheck misses the cross-TU call.

Also gitignores `build-deadcode.log` (linker `--gc-sections` probe output used while measuring the dead-code baseline for #114).

`cppcheck --enable=unusedFunction` drops from 177 to 171. Verified with `make` + `make lint` on macOS.

Refs #106, #114.