### PR TITLE
Drop dead helpers from src/net, src/jobs, src/engine, and header static-inlines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,12 @@ COPY . .
 
 # Build the application
 ARG VERSION=unknown
-RUN make clean && make -j$(nproc) EXTRA_VERSION="${VERSION}"
+ARG EXTRA_CFLAGS=
+ARG EXTRA_LDFLAGS=
+RUN make clean && make -j$(nproc) \
+    EXTRA_VERSION="${VERSION}" \
+    EXTRA_CFLAGS="${EXTRA_CFLAGS}" \
+    EXTRA_LDFLAGS="${EXTRA_LDFLAGS}"
 
 # Runtime image
 FROM alpine:3.21

--- a/src/common/server-functions.c
+++ b/src/common/server-functions.c
@@ -140,11 +140,6 @@ int raise_file_rlimit (int maxfiles) {
 }
 
 
-const char *get_version_string (void) __attribute__ ((weak));
-const char *get_version_string (void) {
-  return "unknown compiled at " __DATE__ " " __TIME__ " by gcc " __VERSION__;
-}
-
 void print_backtrace (void) {
 #ifdef __GLIBC__
   void *buffer[64];
@@ -213,9 +208,6 @@ void ksignal_ex (int sig, void (*handler) (int, siginfo_t *, void *)) {
   }
 }
 
-void engine_set_terminal_attributes (void) __attribute__ ((weak));
-void engine_set_terminal_attributes (void) {}
-
 void extended_debug_handler (int sig, siginfo_t *info, void *cont) {
   ksignal (sig, SIG_DFL);
 
@@ -266,13 +258,6 @@ void set_debug_handlers (void) {
   debug_main_pthread_id = pthread_self ();
 }
 
-void usage (void) __attribute ((weak));
-
-void usage (void) {
-  printf ("usage: %s <args>\n",
-    progname ? progname : "SOMETHING");
-  exit (2);
-}
 
 long long parse_memory_limit (const char *s) {
   long long x;
@@ -313,9 +298,6 @@ int find_parse_option (int val) {
   }
   return -1;
 }
-
-int default_parse_option_func (int a) __attribute__ ((weak));
-int default_parse_option_func (int a) { return -1; }
 
 void parse_option_up (struct engine_parse_option *P) {
   struct engine_parse_option *Q = P - 1;
@@ -610,11 +592,6 @@ int parse_engine_options_long (int argc, char **argv) {
   }
   return 0;
 }
-
-void engine_add_net_parse_options (void) __attribute__ ((weak));
-void engine_add_net_parse_options (void) {}
-void engine_add_engine_parse_options (void) __attribute__ ((weak));
-void engine_add_engine_parse_options (void) {}
 
 void add_builtin_parse_options (void) {
   parse_option_builtin ("verbosity", optional_argument, 0, 'v', LONGOPT_COMMON_SET, "sets or increases verbosity level");

--- a/src/common/server-functions.h
+++ b/src/common/server-functions.h
@@ -90,6 +90,9 @@ void init_parse_options (unsigned keep_mask, const unsigned *keep_options_custom
 
 int parse_engine_options_long (int argc, char **argv);
 int parse_usage (void);
+int default_parse_option_func (int a);
+const char *get_version_string (void);
+void usage (void);
 void parse_option (const char *name, int arg, int *var, int val, const char *help, ...) __attribute__ ((format (printf, 5, 6)));
 void parse_option_ex (const char *name, int arg, int *var, int val, unsigned flags, int (*func)(int), const char *help, ...) __attribute__ ((format (printf, 7, 8)));
 

--- a/src/common/tl-parse.h
+++ b/src/common/tl-parse.h
@@ -233,13 +233,6 @@ int tls_header (struct tl_out_state *tlio_out, struct tl_query_header *header);
 
 int tls_end_ext (struct tl_out_state *tlio_out, int op);
 
-static inline int tlf_init_empty (struct tl_in_state *tlio_in) {
-  return tlf_init_str (tlio_in, "", 0);
-}
-
-static inline int tl_store_end_simple (struct tl_out_state *tlio_out) {
-  return tls_end_ext (tlio_out, 0);
-}
 #define tl_store_end_ext(type) tls_end_ext(tlio_out,type)
 
 static inline int tlf_check (struct tl_in_state *tlio_in, int nbytes) /* {{{ */ {
@@ -290,28 +283,6 @@ static inline int tlf_lookup_int (struct tl_in_state *tlio_in) /* {{{ */ {
 /* }}} */
 #define tl_fetch_lookup_int(...) tlf_lookup_int (tlio_in, ## __VA_ARGS__)
 
-static inline int tlf_lookup_second_int (struct tl_in_state *tlio_in) /* {{{ */ {
-  if (tlf_check (tlio_in, 8) < 0) {
-    return -1;
-  }
-  int x[2];
-  TL_IN_METHODS->fetch_lookup (tlio_in, x, 8);
-  return x[1];
-}
-/* }}} */
-#define tl_fetch_lookup_second_int(...) tlf_lookup_second_int (tlio_in, ## __VA_ARGS__)
-
-static inline long long tlf_lookup_long (struct tl_in_state *tlio_in) /* {{{ */ {
-  if (tlf_check (tlio_in, 8) < 0) {
-    return -1;
-  }
-  long long x;
-  TL_IN_METHODS->fetch_lookup (tlio_in, &x, 8);
-  return x;
-}
-/* }}} */
-#define tl_fetch_lookup_long(...) tlf_lookup_long (tlio_in, ## __VA_ARGS__)
-
 static inline int tlf_lookup_data (struct tl_in_state *tlio_in, void *data, int len) /* {{{ */ {
   if (tlf_check (tlio_in, len) < 0) {
     return -1;
@@ -333,17 +304,6 @@ static inline int tlf_int (struct tl_in_state *tlio_in) /* {{{ */ {
 /* }}} */
 #define tl_fetch_int(...) tlf_int (tlio_in, ## __VA_ARGS__)
 
-static inline double tlf_double (struct tl_in_state *tlio_in) /* {{{ */ {
-  if (__builtin_expect (tlf_check (tlio_in, sizeof (double)) < 0, 0)) {
-    return -1;
-  }
-  double x;
-  __tlf_raw_data (tlio_in, &x, sizeof (x));
-  return x;
-}
-/* }}} */
-#define tl_fetch_double(...) tlf_double (tlio_in, ## __VA_ARGS__)
-
 static inline long long tlf_long (struct tl_in_state *tlio_in) /* {{{ */ {
   if (__builtin_expect (tlf_check (tlio_in, 8) < 0, 0)) {
     return -1;
@@ -354,50 +314,6 @@ static inline long long tlf_long (struct tl_in_state *tlio_in) /* {{{ */ {
 }
 /* }}} */
 #define tl_fetch_long(...) tlf_long (tlio_in, ## __VA_ARGS__)
-
-static inline void tlf_mark (struct tl_in_state *tlio_in) /* {{{ */ {
-  TL_IN_METHODS->fetch_mark (tlio_in);
-}
-/* }}} */
-#define tl_fetch_mark(...) tlf_mark (tlio_in, ## __VA_ARGS__)
-
-static inline void tlf_mark_restore (struct tl_in_state *tlio_in) /* {{{ */ {
-  TL_IN_METHODS->fetch_mark_restore (tlio_in);
-}
-/* }}} */
-#define tl_fetch_mark_restore(...) tlf_mark_restore (tlio_in, ## __VA_ARGS__)
-
-static inline void tlf_mark_delete (struct tl_in_state *tlio_in) /* {{{ */ {
-  TL_IN_METHODS->fetch_mark_delete (tlio_in);
-}
-/* }}} */
-#define tl_fetch_mark_delete(...) tlf_mark_delete (tlio_in, ## __VA_ARGS__)
-
-static inline int tlf_string_len (struct tl_in_state *tlio_in, int max_len) /* {{{ */ {
-  if (tlf_check (tlio_in, 4) < 0) {
-    return -1;
-  }
-  int x = 0;
-  __tlf_raw_data (tlio_in, &x, 1);
-  if (x == 255) {
-    tlf_set_error (tlio_in, TL_ERROR_SYNTAX, "String len can not start with 0xff");
-    return -1;
-  }
-  if (x == 254) {
-    __tlf_raw_data (tlio_in, &x, 3);
-  }
-  if (x > max_len) {
-    tlf_set_error_format (tlio_in, TL_ERROR_TOO_LONG_STRING, "string is too long: max_len = %d, len = %d", max_len, x);
-    return -1;
-  }
-  if (x > TL_IN_REMAINING) {
-    tlf_set_error_format (tlio_in, TL_ERROR_NOT_ENOUGH_DATA, "string is too long: remaining_bytes = %d, len = %d", TL_IN_REMAINING, x);
-    return -1;
-  }
-  return x;
-}
-/* }}} */
-#define tl_fetch_string_len(...) tlf_string_len (tlio_in, ## __VA_ARGS__)
 
 static inline int tlf_pad (struct tl_in_state *tlio_in) /* {{{ */ {
   int pad = (-TL_IN_POS) & 3;
@@ -427,72 +343,6 @@ static inline int tlf_raw_data (struct tl_in_state *tlio_in, void *buf, int len)
 /* }}} */
 #define tl_fetch_raw_data(...) tlf_raw_data (tlio_in, ## __VA_ARGS__)
 
-static inline int tlf_string_data (struct tl_in_state *tlio_in, char *buf, int len) /* {{{ */ {
-  if (tlf_check (tlio_in, len) < 0) {
-    return -1;
-  }
-  __tlf_raw_data (tlio_in, buf, len);
-  if (tlf_pad (tlio_in) < 0) {
-    return -1;
-  }
-  return len;
-}
-/* }}} */
-#define tl_fetch_string_data(...) tlf_string_data (tlio_in, ## __VA_ARGS__)
-
-static inline int tlf_skip_string_data (struct tl_in_state *tlio_in, int len) /* {{{ */ {
-  if (tlf_check (tlio_in, len) < 0) {
-    return -1;
-  }
-  __tlf_skip_raw_data (tlio_in, len);
-  if (tlf_pad (tlio_in) < 0) {
-    return -1;
-  }
-  return len;
-}
-/* }}} */
-#define tl_fetch_skip_string_data(...) tlf_skip_string_data (tlio_in, ## __VA_ARGS__)
-
-static inline int tlf_string (struct tl_in_state *tlio_in, char *buf, int max_len) /* {{{ */ {
-  int l = tlf_string_len (tlio_in, max_len);
-  if (l < 0) {
-    return -1;
-  }
-  if (tlf_string_data (tlio_in, buf, l) < 0) {
-    return -1;
-  }
-  return l;
-}
-/* }}} */
-#define tl_fetch_string(...) tlf_string (tlio_in, ## __VA_ARGS__)
-
-static inline int tlf_skip_string (struct tl_in_state *tlio_in, int max_len) /* {{{ */ {
-  int l = tlf_string_len (tlio_in, max_len);
-  if (l < 0) {
-    return -1;
-  }
-  if (tlf_skip_string_data (tlio_in, l) < 0) {
-    return -1;
-  }
-  return l;
-}
-/* }}} */
-#define tl_fetch_skip_string(...) tlf_skip_string (tlio_in, ## __VA_ARGS__)
-
-static inline int tlf_string0 (struct tl_in_state *tlio_in, char *buf, int max_len) /* {{{ */ {
-  int l = tlf_string_len (tlio_in, max_len);
-  if (l < 0) {
-    return -1;
-  }
-  if (tlf_string_data (tlio_in, buf, l) < 0) {
-    return -1;
-  }
-  buf[l] = 0;
-  return l;
-}
-/* }}} */
-#define tl_fetch_string0(...) tlf_string0 (tlio_in, ## __VA_ARGS__)
-
 static inline int tlf_error (struct tl_in_state *tlio_in) /* {{{ */{
   return TL_ERROR != 0;
 }
@@ -508,16 +358,6 @@ static inline int tlf_end (struct tl_in_state *tlio_in) /* {{{ */ {
 }
 /* }}} */
 #define tl_fetch_end(...) tlf_end (tlio_in, ## __VA_ARGS__)
-
-static inline int tlf_check_str_end (struct tl_in_state *tlio_in, int size) /* {{{ */ {
-  if (TL_IN_REMAINING != size + ((-size - TL_IN_POS) & 3)) {
-    tlf_set_error_format (tlio_in, TL_ERROR_EXTRA_DATA, "extra %d bytes after query", TL_IN_REMAINING - size - ((-size - TL_IN_POS) & 3));    
-    return -1;
-  }
-  return 1;
-}
-/* }}} */
-#define tl_fetch_check_str_end(...) tlf_check_str_end (tlio_in, ## __VA_ARGS__)
 
 static inline int tlf_unread (struct tl_in_state *tlio_in) /* {{{ */ {
   return TL_IN_REMAINING;
@@ -599,12 +439,6 @@ static inline int tls_long (struct tl_out_state *tlio_out, long long x) /* {{{ *
 /* }}} */
 #define tl_store_long(...) tls_long (tlio_out, ## __VA_ARGS__)
 
-static inline int tls_double (struct tl_out_state *tlio_out, double x) /* {{{ */ {
-  assert (tls_check (tlio_out, 8) >= 0);
-  __tls_raw_data (tlio_out, &x, 8);
-  return 0;
-}
-/* }}} */
 #define tl_store_double(...) tls_double (tlio_out, ## __VA_ARGS__)
 
 static inline int tls_string_len (struct tl_out_state *tlio_out, int len) /* {{{ */ {
@@ -734,26 +568,6 @@ static inline int tlf_int_range (struct tl_in_state *tlio_in, int min, int max) 
 /* }}} */
 #define tl_fetch_int_range(...) tlf_int_range (tlio_in, ## __VA_ARGS__)
 
-static inline int tlf_positive_int (struct tl_in_state *tlio_in) {
-  return tlf_int_range (tlio_in, 1, 0x7fffffff);
-}
-#define tl_fetch_positive_int(...) tlf_positive_int (tlio_in, ## __VA_ARGS__)
-
-static inline int tlf_nonnegative_int (struct tl_in_state *tlio_in) {
-  return tlf_int_range (tlio_in, 0, 0x7fffffff);
-}
-#define tl_fetch_nonnegative_int(...) tlf_nonnegative_int (tlio_in, ## __VA_ARGS__)
-
-static inline int tlf_int_subset (struct tl_in_state *tlio_in, int set) /* {{{ */ {
-  int x = tlf_int (tlio_in);
-  if (x & ~set) {
-    tlf_set_error_format (tlio_in, TL_ERROR_VALUE_NOT_IN_RANGE, "Expected int32 with only bits 0x%02x allowed, 0x%02x presented", set, x);
-  }
-  return x;
-}
-/* }}} */
-#define tl_fetch_int_subset(...) tlf_int_subset (tlio_in, ## __VA_ARGS__)
-
 static inline long long tlf_long_range (struct tl_in_state *tlio_in, long long min, long long max) /* {{{ */ {
   long long x = tlf_long (tlio_in);
   if (x < min || x > max) {
@@ -762,52 +576,6 @@ static inline long long tlf_long_range (struct tl_in_state *tlio_in, long long m
   return x;
 }
 /* }}} */
-
-static inline long long tlf_positive_long (struct tl_in_state *tlio_in) {
-  return tlf_long_range (tlio_in, 1, 0x7fffffffffffffffll);
-}
-#define tl_fetch_positive_long(...) tlf_positive_long (tlio_in, ## __VA_ARGS__)
-
-static inline long long tlf_nonnegative_long (struct tl_in_state *tlio_in) {
-  return tlf_long_range (tlio_in, 0, 0x7fffffffffffffffll);
-}
-#define tl_fetch_nonnegative_long(...) tlf_nonnegative_long (tlio_in, ## __VA_ARGS__)
-
-static int _tlf_raw_message (struct tl_in_state *tlio_in, struct raw_message *raw, int len, int advance) {
-  if (__builtin_expect (tlf_check (tlio_in, len) < 0, 0)) {
-    return -1;
-  }
-
-  if (advance) {
-    TL_IN_METHODS->fetch_raw_message (tlio_in, raw, len);
-    TL_IN_POS += len;
-    TL_IN_REMAINING -= len;
-  } else {
-    TL_IN_METHODS->fetch_lookup_raw_message (tlio_in, raw, len);
-  }
-
-  return 0;
-}
-
-static inline int tlf_raw_message (struct tl_in_state *tlio_in, struct raw_message *raw, int bytes) {
-  return _tlf_raw_message (tlio_in, raw, bytes, 1);
-}
-#define tl_fetch_raw_message(...) tlf_raw_message (tlio_in, ## __VA_ARGS__)
-
-static inline int tlf_lookup_raw_message (struct tl_in_state *tlio_in, struct raw_message *raw, int bytes) {
-  return _tlf_raw_message (tlio_in, raw, bytes, 0);
-}
-#define tl_fetch_lookup_raw_message(...) tlf_lookup_raw_message (tlio_in, ## __VA_ARGS__)
-
-static inline void tlf_copy_error (struct tl_in_state *tlio_in, struct tl_out_state *tlio_out) {
-  if (!tlio_out->error) {
-    if (tlio_in->error) {
-      tlio_out->error = strdup (tlio_in->error);
-      tlio_out->errnum = tlio_in->errnum;
-    }
-  }
-}
-#define tl_copy_error(...) tlf_copy_error (tlio_in, tlio_out, ## __VA_ARGS__)
 
 struct tl_in_state *tl_in_state_alloc (void);
 void tl_in_state_free (struct tl_in_state *tlio_in);

--- a/src/engine/engine-rpc.c
+++ b/src/engine/engine-rpc.c
@@ -89,10 +89,6 @@ struct tl_out_state *tl_aio_init_store (enum tl_type type, struct process_id *pi
 
 static long long queries_allocated;
 
-long long engine_get_allocated_queries (void) {
-  return queries_allocated;
-}
-
 
 #define rpc_custom_op_cmp(a,b) (a->op < b->op ? -1 : a->op > b->op ? 1 : 0)
 
@@ -245,26 +241,8 @@ static int process_act_atom_subjob (job_t job, int op, struct job_thread *JT);
 
 /* {{{ auto TL parse functions weak declaration */
 
-struct paramed_type *skip_function_any (struct tl_in_state *tlio_in) __attribute__ ((weak));
-struct paramed_type *skip_function_any (struct tl_in_state *tlio_in) { return NULL; }
-struct paramed_type *fetch_function_any (struct tl_in_state *tlio_in) __attribute__ ((weak));
-struct paramed_type *fetch_function_any (struct tl_in_state *tlio_in) { return NULL; }
-
-int skip_type_any (struct tl_in_state *tlio_in, struct paramed_type *P) __attribute__ ((weak));
-int skip_type_any (struct tl_in_state *tlio_in, struct paramed_type *P) { return -1; }
-int fetch_type_any (struct tl_in_state *tlio_in, struct paramed_type *P) __attribute__ ((weak));
-int fetch_type_any (struct tl_in_state *tlio_in, struct paramed_type *P) { return -1; }
-
-void free_vars_to_be_freed (void) __attribute__ ((weak));
-void free_vars_to_be_freed (void) {}
-void tl_printf_clear (void) __attribute__ ((weak));
-void tl_printf_clear (void) {}
-
 void paramed_type_free (struct paramed_type *P) __attribute__ ((weak));
 void paramed_type_free (struct paramed_type *P) {}
-
-struct paramed_type *paramed_type_dup (struct paramed_type *P) __attribute__ ((weak));
-struct paramed_type *paramed_type_dup (struct paramed_type *P) { return 0; }
 
 /* }}} */
 

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -535,14 +535,6 @@ void engine_rpc_stats (struct tl_out_state *tlio_out) {
   tl_store_stats (tlio_out, data_buf, 0);
 }
 
-void output_engine_stats (void) {
-  int len = engine_prepare_stats ();
-  if (len > 0) {
-    kprintf ("-------------- network/memcache statistics ------------\n");
-    kwrite (2, data_buf, len);
-  }
-}
-
 int default_get_op (struct tl_in_state *tlio_in) {
   return tl_fetch_lookup_int ();
 }

--- a/src/jobs/jobs.c
+++ b/src/jobs/jobs.c
@@ -351,9 +351,6 @@ void update_all_thread_stats (void) {
   }
 }
 
-void wakeup_main_thread (void) __attribute__ ((weak));
-void wakeup_main_thread (void) {}
-
 #define JOB_THREAD_STACK_SIZE        (4 << 20)
 
 #define JTS_CREATED 1
@@ -1236,11 +1233,6 @@ int insert_job_into_job_list (job_t list_job, JOB_REF_ARG(job), int mode) {
   wj->jl_job = PTR_MOVE (job);
   wj->jl_flags = mode;
   return insert_node_into_job_list (list_job, (struct job_list_node *) wj);
-}
-
-int insert_connection_into_job_list (job_t list_job, connection_job_t c) {
-  assert (0);
-  return 0;
 }
 
 struct job_timer_manager_extra {

--- a/src/jobs/jobs.h
+++ b/src/jobs/jobs.h
@@ -283,12 +283,6 @@ void job_change_signals (job_t job, unsigned long long job_signals);
 int schedule_job (JOB_REF_ARG (job));
 
 job_t job_incref (job_t job);
-static inline job_t job_incref_f (job_t job) {
-  if (job) {
-    job_incref (job);
-  }
-  return job;
-}
 void job_decref (JOB_REF_ARG (job));	// if job->j_refcnt becomes 0, invokes j_execute with op = JS_FREE
 static inline void job_decref_f (job_t job) {
   job_decref (JOB_REF_PASS (job));
@@ -312,9 +306,6 @@ static inline int check_parent_job_validity (job_t job) {
 }
 static inline int parent_job_aborted (job_t job) {
   return (job->j_status & JSP_PARENT_INCOMPLETE) && job->j_parent && check_job_completion (job->j_parent);
-}
-static inline int job_parent_ptr_valid (job_t job) {
-  return (!(job->j_status & JSP_PARENT_RESPTR) || check_parent_job_validity (job));
 }
 static inline int job_fatal (job_t job, int error) {
   if (!job->j_error) {
@@ -369,17 +360,7 @@ static inline void check_thread_class (int class) {
 void job_message_send (JOB_REF_ARG (job), JOB_REF_ARG (src), unsigned int type, struct raw_message *raw, int dup, int payload_ints, const unsigned int *payload, unsigned int flags, void (*destructor)(struct job_message *M));
 void job_message_send_fake (JOB_REF_ARG (job), int (*receive_message)(job_t job, struct job_message *M, void *extra), void *extra, JOB_REF_ARG (src), unsigned int type, struct raw_message *raw, int dup, int payload_ints, const unsigned int *payload, unsigned int flags, void (*destructor)(struct job_message *M));
 //void job_message_send_data (JOB_REF_ARG (job), JOB_REF_ARG (src), unsigned int type, void *ptr1, void *ptr2, int int1, long long long1, int payload_ints, const unsigned int *payload, unsigned int flags);
-static inline void job_message_send_empty (JOB_REF_ARG (job), JOB_REF_ARG (src), unsigned int type, unsigned int flags) {
-  job_message_send (JOB_REF_PASS (job), JOB_REF_PASS (src), type, &empty_rwm, 1, 0, NULL, flags, NULL);
-}
-    
 #define TL_TRUE 0x3fedd339
-static inline int job_message_answer_true (struct job_message *M) {    
-  if (M->src) {
-    job_message_send (JOB_REF_PASS (M->src), JOB_REF_NULL, TL_TRUE, &empty_rwm, 1, M->payload_ints, M->payload, JMC_EXTRACT_ANSWER (M->flags), NULL);
-  }
-  return 1;
-}
 
 static inline int job_message_continuation (job_t job, struct job_message *M, int payload_magic) {
   if (M->payload_ints >= 1) {
@@ -414,18 +395,6 @@ struct job_message_payload {
   int payload_ints;
   unsigned int payload[0];
 };
-
-static inline struct job_message_payload *job_message_payload_alloc (JOB_REF_ARG (job), int message_class, int payload_ints, unsigned int *payload) {
-  struct job_message_payload *P = malloc (sizeof (*P) + 4 * payload_ints);
-  if (!P) {
-    return NULL;
-  }
-  P->message_class = message_class;
-  P->payload_ints = payload_ints;
-  P->job = PTR_MOVE (job);
-  memcpy (P->payload, payload, 4 * payload_ints);
-  return P;
-}
 
 long long jobs_get_allocated_memoty (void);
 

--- a/src/mtproto/mtproto-config.c
+++ b/src/mtproto/mtproto-config.c
@@ -227,14 +227,6 @@ struct mf_cluster *mf_cluster_lookup (struct mf_config *MC, int cluster_id, int 
   return force ? MC->default_cluster : 0;
 }
 
-void dump_mf_cluster (struct mf_cluster *MFC) {
-  int i;
-  kprintf ("Current state of cluster `%s` (N=%d, M=%d, alloc=%d):\n", "(nil)", MFC->targets_num, MFC->write_targets_num, MFC->targets_allocated);
-  for (i = 0; i < MFC->targets_num; i++) {
-    kprintf ("Target #%d [%c]: %s:%d\n", i, i < MFC->write_targets_num ? 'W' : 'R', show_ip (ntohl (CONN_TARGET_INFO(MFC->cluster_targets[i])->target.s_addr)), CONN_TARGET_INFO(MFC->cluster_targets[i])->port);
-  }
-}
-
 static void preinit_config (struct mf_config *MC) {
   MC->tot_targets = 0;
   MC->auth_clusters = 0;

--- a/src/net/net-connections.c
+++ b/src/net/net-connections.c
@@ -1706,12 +1706,6 @@ void free_later_act (void) {
   }
 }
 
-void free_connection_tree_ptr (struct tree_connection *T) /* {{{ */ {
-  free_tree_ptr_connection (T);
-}
-/* }}} */ 
-
-
 void incr_active_dh_connections (void) {
   MODULE_STAT->active_dh_connections ++;
 }

--- a/src/net/net-connections.h
+++ b/src/net/net-connections.h
@@ -411,7 +411,6 @@ int init_listening_connection (int fd, conn_type_t *type, void *extra);
 int init_listening_tcpv6_connection (int fd, conn_type_t *type, void *extra, int mode);
 
 //struct tree_connection *get_connection_tree_ptr (struct tree_connection **);
-//void free_connection_tree_ptr (struct tree_connection *);
 
 struct free_later {
   void *ptr;

--- a/src/net/net-connections.h
+++ b/src/net/net-connections.h
@@ -334,7 +334,6 @@ struct connections_stat {
 static inline const char *show_ip46 (unsigned ip, const unsigned char ipv6[16]) { return ip ? show_ip (ip) : show_ipv6 (ipv6); }
 static inline const char *show_our_ip (connection_job_t c) { return show_ip46 (CONN_INFO(c)->our_ip, CONN_INFO(c)->our_ipv6); }
 static inline const char *show_remote_ip (connection_job_t c) { return show_ip46 (CONN_INFO(c)->remote_ip, CONN_INFO(c)->remote_ipv6); }
-static inline const char *show_our_socket_ip (socket_connection_job_t c) { return show_ip46 (SOCKET_CONN_INFO(c)->our_ip, SOCKET_CONN_INFO(c)->our_ipv6); }
 static inline const char *show_remote_socket_ip (socket_connection_job_t c) { return show_ip46 (SOCKET_CONN_INFO(c)->remote_ip, SOCKET_CONN_INFO(c)->remote_ipv6); }
 
 void fetch_connections_stat (struct connections_stat *st);
@@ -356,9 +355,6 @@ int destroy_target (JOB_REF_ARG (CTJ));
 conn_target_job_t create_target (struct conn_target_info *source, int *was_created);
 void compute_next_reconnect (conn_target_job_t CT);
 
-
-static inline connection_job_t connection_incref (connection_job_t C) { return job_incref (C); }
-static inline void connection_decref (connection_job_t C) { job_decref (JOB_REF_PASS (C)); }
 
 connection_job_t connection_get_by_fd (int fd);
 connection_job_t connection_get_by_fd_generation (int fd, int generation);
@@ -389,10 +385,6 @@ void connection_write_close (connection_job_t C);
 #define write_out_chk(c,data,len) assert(write_out (&CONN_INFO(c)->Out, data, len) == len);
 #define write_out_old(c,data,len) write_out(&CONN_INFO(c)->Out, data, len)
 #define read_in_old(c,data,len) read_in(&CONN_INFO(c)->In, data, len)
-
-static inline int is_ipv6_localhost (unsigned char ipv6[16]) {
-  return !*(long long *)ipv6 && ((long long *)ipv6)[1] == 1LL << 56;
-}
 
 void assert_net_cpu_thread (void);
 void assert_net_net_thread (void);

--- a/src/net/net-crypto-aes.c
+++ b/src/net/net-crypto-aes.c
@@ -309,22 +309,6 @@ int aes_create_keys (struct aes_key_data *R, int am_client, const char nonce_ser
   return 1;
 }
 
-int get_crypto_key_id (void) {
-  if (main_secret.secret_len >= 4) {
-    return main_secret.key_signature;
-  } else {
-    return 0;
-  }
-}
-
-int get_extra_crypto_key_ids (int *buf, int max) {
-  return 0;
-}
-
-int is_valid_crypto_key_id (int x) {
-  return x && x == main_secret.key_signature && main_secret.secret_len >= 4;
-}
-
 void free_crypto_temp (void *crypto, int len) {
   memset (crypto, 0, len);
   free (crypto);

--- a/src/net/net-msg-buffers.c
+++ b/src/net/net-msg-buffers.c
@@ -314,13 +314,6 @@ void free_msg_buffers_chunk_internal (struct msg_buffers_chunk *C, struct msg_bu
 }
 
 
-void free_msg_buffers_chunk (struct msg_buffers_chunk *C) {
-  assert (C->magic == MSG_CHUNK_USED_LOCKED_MAGIC);
-  assert (C->free_cnt[1] == C->tot_buffers);
-
-  free_msg_buffers_chunk_internal (C, C->ch_head);
-}
-
 int init_msg_buffers (long max_buffer_bytes) {
   if (!max_buffer_bytes) {
     max_buffer_bytes = max_allocated_buffer_bytes ?: MSG_DEFAULT_MAX_ALLOCATED_BYTES;

--- a/src/net/net-stats.c
+++ b/src/net/net-stats.c
@@ -63,8 +63,6 @@ long long max_queries_allocated_prev_sec;
 long long total_vv_tree_nodes;
 
 int tl_rpc_op_stat __attribute__ ((weak));
-int op_stat_write (stats_buffer_t *sb) __attribute__ ((weak));
-int op_stat_write (stats_buffer_t *sb) { return 0; }
 
 
 int my_pid;
@@ -83,10 +81,6 @@ int timers_prepare_stat (stats_buffer_t *sb);
 int rpc_targets_prepare_stat (stats_buffer_t *sb);
 
 //static double safe_div (double x, double y) { return y > 0 ? x/y : 0; }
-
-int recent_idle_percent (void) {
-  return a_idle_quotient > 0 ? a_idle_time / a_idle_quotient * 100 : a_idle_time;
-}
 
 extern long long epoll_calls;
 extern long long epoll_intr;
@@ -155,12 +149,4 @@ int prepare_stats (char *buff, int buff_size) {
     "stats_generate_time\t%.6f\n",
     get_utime_monotonic () - um);
   return sb.pos;
-}
-
-void output_std_stats (void) {
-  static char debug_stats[1 << 20];
-  int len = prepare_stats (debug_stats, sizeof (debug_stats) - 1);
-  if (len > 0) {
-    kprintf ("-------------- network statistics ------------\n%s\n-------------------------------------\n", debug_stats);
-  }
 }

--- a/src/vv/vv-tree.h
+++ b/src/vv/vv-tree.h
@@ -21,41 +21,6 @@
               2014-2016 Vitaly Valtman     
 */
 
-struct tree_any_ptr {
-  struct tree_any_ptr *left, *right;
-  void *x;
-  int y;
-};
-
-static inline void tree_act_any (struct tree_any_ptr *T, void (*f)(void *)) {
-  if (!T) { return; }
-  tree_act_any (T->left, f);
-  f (T->x);
-  tree_act_any (T->right, f);
-}
-
-static inline void tree_act_any_ex (struct tree_any_ptr *T, void (*f)(void *, void *), void *extra) {
-  if (!T) { return; }
-  tree_act_any_ex (T->left, f, extra);
-  f (T->x, extra);
-  tree_act_any_ex (T->right, f, extra);
-}
-
-static inline void tree_act_any_ex2 (struct tree_any_ptr *T, void (*f)(void *, void *, void *), void *extra, void *extra2) {
-  if (!T) { return; }
-  tree_act_any_ex2 (T->left, f, extra, extra2);
-  f (T->x, extra, extra2);
-  tree_act_any_ex2 (T->right, f, extra, extra2);
-}
-
-static inline void tree_act_any_ex3 (struct tree_any_ptr *T, void (*f)(void *, void *, void *, void *), void *extra, void *extra2, void *extra3) {
-  if (!T) { return; }
-  tree_act_any_ex3 (T->left, f, extra, extra2, extra3);
-  f (T->x, extra, extra2, extra3);
-  tree_act_any_ex3 (T->right, f, extra, extra2, extra3);
-}
-
-
 #define DEFINE_HASH(prefix,name,value_t,value_compare,value_hash) \
   prefix hash_elem_ ## name ## _t *hash_lookup_ ## name (hash_table_ ## name ## _t *T, value_t x) __attribute__ ((unused)); \
   prefix void hash_insert_ ## name (hash_table_ ## name ## _t *T, value_t x) __attribute__ ((unused)); \


### PR DESCRIPTION
Follows PR #118. Same pattern: each commit removes vestigial helpers
that no source file in the project references.

Most of the deletions are weak-attribute stubs in \`server-functions.c\`,
\`jobs.c\`, and \`engine-rpc.c\` that exist as fallbacks for stronger
definitions elsewhere in the engine — the strong versions are always
provided in this project, so the weak fallback bodies are dead.

A linker-level \`--print-gc-sections\` probe (with
\`-ffunction-sections -fdata-sections\` / \`-Wl,--gc-sections\`) drops from
~10 \`.text\` removals in \`src/\` to 3 after this PR. The 3 that remain
(\`count_connection_num\`, \`find_bad_connection\`, \`fail_connection_gw\`
in \`net-conn-targets.c\`) are compiler-inlining artifacts: each function
has real source-level callers, but the compiler inlined every call site
and the standalone copies became unreferenced. They cannot be deleted
from source without breaking the build.

Cppcheck \`unusedFunction\` drops from 157 to 111. Most of the remaining
findings are cross-translation-unit false positives — cppcheck's
analyzer doesn't reliably follow calls through wrapper macros or across
all TUs in this codebase. They are kept until the cppcheck cross-TU
reliability question is resolved separately.

The \`Dockerfile\` change forwards \`EXTRA_CFLAGS\` / \`EXTRA_LDFLAGS\`
through the build, so ad-hoc probe builds don't need patches.