### PR TITLE
common: simplify the load_config() function

### DIFF
--- a/src/common/parse-config.c
+++ b/src/common/parse-config.c
@@ -19,6 +19,7 @@
 */
 
 #include <assert.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -172,37 +173,50 @@ void reset_config (void) {
   cfg_lno = 0;
 }
 
-int load_config (const char *file, int fd) {
+int load_config (const char *file) {
+  int fd = -1;
+  int ret = 0;
+
+  if (!file)
+    return -EINVAL;
+
   if (!config_buff) {
     config_buff = malloc (MAX_CONFIG_SIZE+4);
-    assert (config_buff);
+    if (!config_buff)
+      return -ENOMEM;
   }
+
+  fd = open (file, O_RDONLY);
   if (fd < 0) {
-    fd = open (file, O_RDONLY);
-    if (fd < 0) {
-      fprintf (stderr, "Can not open file %s: %m\n", file);
-      return -1;
-    }
+    fprintf (stderr, "Can not open file %s: %m\n", file);
+    return -EINVAL;
   }
-  int r;
-  config_bytes = r = read (fd, config_buff, MAX_CONFIG_SIZE + 1);
-  if (r < 0) {
-    fprintf (stderr, "error reading configuration file %s: %m\n", config_name);
-    return -2;
-  }
-  if (r > MAX_CONFIG_SIZE) {
-    fprintf (stderr, "configuration file %s too long (max %d bytes)\n", config_name, MAX_CONFIG_SIZE);
-    return -2;
+
+  config_bytes = read (fd, config_buff, MAX_CONFIG_SIZE + 1);
+  if (config_bytes < 0) {
+    fprintf (stderr, "error reading configuration file %s: %m\n", file);
+    config_bytes = 0;
+    ret = -EIO;
+    goto out;
+  } else if (config_bytes > MAX_CONFIG_SIZE) {
+    fprintf (stderr, "configuration file %s too long (max %d bytes)\n", file, MAX_CONFIG_SIZE);
+    config_bytes = 0;
+    ret = -EIO;
+    goto out;
   }
   if (config_name) {
     free (config_name);
-  }
-  if (file) {
-    config_name = strdup (file);
+    config_name = NULL;
   }
 
+  config_name = strdup (file);
   reset_config ();
-  return fd;
+
+out:
+  if (fd >= 0)
+    close (fd);
+
+  return ret;
 }
 
 void md5_hex_config (char *out) {

--- a/src/common/parse-config.h
+++ b/src/common/parse-config.h
@@ -29,7 +29,7 @@ int cfg_getword (void);
 void syntax (const char *msg, ...);
 int expect_lexem (int lexem);
 void reset_config (void);
-int load_config (const char *file, int fd);
+int load_config (const char *file);
 void md5_hex_config (char *out);
 struct hostent *cfg_gethost (void);
 struct hostent *cfg_gethost_ex (int verb);

--- a/src/mtproto/mtproto-config.c
+++ b/src/mtproto/mtproto-config.c
@@ -239,14 +239,14 @@ static void preinit_config (struct mf_config *MC) {
 
 // flags = 0 -- syntax check only (first pass), flags = 1 -- create targets and points as well (second pass)
 // flags: +2 = allow proxies, +4 = allow proxies only, +16 = do not load file
-int parse_config (struct mf_config *MC, int flags, int config_fd) {
+int parse_config (struct mf_config *MC, int flags) {
   conn_target_job_t *targ_ptr;
   int have_proxy = 0;
 
   assert (flags & 4);
 
   if (!(flags & 17)) {
-    if (load_config (config_filename, config_fd) < 0) {
+    if (load_config (config_filename) < 0) {
       return -2;
     }
   }
@@ -354,16 +354,9 @@ int do_reload_config (int flags) {
   int res;
   need_reload_config = 0;
 
-  int fd = -1;
   assert (flags & 4);
 
   if (!(flags & 16)) {
-    fd = open (config_filename, O_RDONLY);
-    if (fd < 0) {
-      kprintf ("cannot re-read config file %s: %m\n", config_filename);
-      return -1;
-    }
-
     res = kdb_load_hosts ();
 
     if (res > 0) {
@@ -371,14 +364,7 @@ int do_reload_config (int flags) {
     }
   }
 
-  res = parse_config (NextConf, flags & -2, fd);
-
-  if (fd >= 0) {
-    close (fd);
-  }
-
-  //  clear_config (NextConf);
-  
+  res = parse_config (NextConf, flags & -2);
   if (res < 0) {
     kprintf ("error while re-reading config file %s, new configuration NOT applied\n", config_filename);
     return res;
@@ -388,8 +374,7 @@ int do_reload_config (int flags) {
     return 0;
   }
 
-  res = parse_config (NextConf, flags | 1, -1);
-
+  res = parse_config (NextConf, flags | 1);
   if (res < 0) {
     clear_config (NextConf, 0);
     kprintf ("fatal error while re-reading config file %s\n", config_filename);


### PR DESCRIPTION
This function tries to do too many things - copy a buffer from a passed file descriptor, or open a new file, read/copy buffer and return its file descriptor; in this case, the result is ignored at the place of the call.

Tested by compiling on Arch Linux with `make` and `make lint`.
Tested on VPS Debian GNU/Linux 12 with `./objs/bin/teleproxy -u nobody -p 8888 -H 8998 -S $(cat 1.secr) -M1 --aes-pwd proxy-secret proxy-multi.conf` and mobile Telegram client for Android.