### PR TITLE
Consolidate zero_ipv6 into src/common/ip-utils.{c,h}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ LIB_OBJS_NORMAL := \
 	${OBJ}/src/common/kprintf.o \
 	${OBJ}/src/common/precise-time.o ${OBJ}/src/common/cpuid.o \
 	${OBJ}/src/common/server-functions.o ${OBJ}/src/common/crc32.o \
+	${OBJ}/src/common/ip-utils.o \
 	${OBJ}/src/common/toml/tomlc17.o ${OBJ}/src/common/toml/tomlc17-scan.o \
 	${OBJ}/src/common/toml-config.o \
 	${OBJ}/src/common/qrcode/qrcodegen.o \

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -71,11 +71,14 @@ run: $(TARGETS)
 mtproto-dc-table.o: ../src/mtproto/mtproto-dc-table.c ../src/mtproto/mtproto-dc-table.h
 	$(CC) $(TEST_CFLAGS) $(FUZZ_CINCLUDE) -c -o $@ $<
 
-test_dc_lookup: test_dc_lookup.c mtproto-dc-table.o
+ip-utils.o: ../src/common/ip-utils.c ../src/common/ip-utils.h
+	$(CC) $(TEST_CFLAGS) $(FUZZ_CINCLUDE) -c -o $@ $<
+
+test_dc_lookup: test_dc_lookup.c mtproto-dc-table.o ip-utils.o
 	$(CC) $(TEST_CFLAGS) $(FUZZ_CINCLUDE) -o $@ $^
 
 test: $(TEST_TARGETS)
 	@for t in $(TEST_TARGETS); do echo "=== $$t ==="; ./$$t || exit 1; done
 
 clean:
-	rm -f $(TARGETS) $(TEST_TARGETS) $(PARSE_OBJS) $(OBFS2_OBJS) $(JA4_OBJS) mtproto-dc-table.o
+	rm -f $(TARGETS) $(TEST_TARGETS) $(PARSE_OBJS) $(OBFS2_OBJS) $(JA4_OBJS) mtproto-dc-table.o ip-utils.o

--- a/src/common/ip-utils.c
+++ b/src/common/ip-utils.c
@@ -1,0 +1,3 @@
+#include "common/ip-utils.h"
+
+const unsigned char zero_ipv6[16] = {};

--- a/src/common/ip-utils.h
+++ b/src/common/ip-utils.h
@@ -1,0 +1,3 @@
+#pragma once
+
+extern const unsigned char zero_ipv6[16];

--- a/src/mtproto/mtproto-check.c
+++ b/src/mtproto/mtproto-check.c
@@ -28,6 +28,7 @@
 
 #include <openssl/rand.h>
 
+#include "common/ip-utils.h"
 #include "common/platform.h"
 #include "common/toml-config.h"
 #include "mtproto/mtproto-dc-table.h"
@@ -403,7 +404,6 @@ static void check_dc (struct check_context *ctx, int dc_id) {
   }
 
   const struct dc_addr *addr = &dc->addrs[0];
-  static const unsigned char zero_ipv6[16] = {};
 
   char ip_str[INET6_ADDRSTRLEN] = "?";
   struct sockaddr_storage ss;

--- a/src/mtproto/mtproto-dc-table.c
+++ b/src/mtproto/mtproto-dc-table.c
@@ -25,6 +25,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <arpa/inet.h>
+#include "common/ip-utils.h"
 #include "common/platform.h"
 #include "mtproto/mtproto-dc-table.h"
 
@@ -191,7 +192,6 @@ int direct_dc_override (int dc_id, const char *host, int port) {
 int direct_dc_probe_ipv6 (void) {
   dc_table_init ();
 
-  static const unsigned char zero_ipv6[16] = {};
   if (memcmp (prod_table[1].addrs[0].ipv6, zero_ipv6, 16) == 0) {
     return 0;
   }

--- a/src/net/net-tcp-direct-dc.c
+++ b/src/net/net-tcp-direct-dc.c
@@ -39,6 +39,7 @@
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
 
+#include "common/ip-utils.h"
 #include "common/kprintf.h"
 #include "common/precise-time.h"
 #include "common/resolver.h"
@@ -562,7 +563,6 @@ static void socks5_send_connect (connection_job_t C) {
   assert (dc && addr_idx < dc->addr_count);
   const struct dc_addr *addr = &dc->addrs[addr_idx];
 
-  static const unsigned char zero_ipv6[16] = {};
   int has_ipv6 = memcmp (addr->ipv6, zero_ipv6, 16) != 0;
   int use_ipv6 = ipv6_enabled && has_ipv6;
 
@@ -707,8 +707,6 @@ static int tcp_direct_dc_connected (connection_job_t C) {
 /* Try to establish a DC connection using one of the entry's addresses.
    Returns the connection job on success, or NULL if all addresses failed. */
 static job_t direct_try_dc_addrs (connection_job_t C, const struct dc_entry *dc, int target_dc) {
-  static const unsigned char zero_ipv6[16] = {};
-
   for (int i = 0; i < dc->addr_count; i++) {
     const struct dc_addr *addr = &dc->addrs[i];
     int has_ipv6 = memcmp (addr->ipv6, zero_ipv6, 16) != 0;

--- a/src/net/net-tcp-rpc-ext-server.c
+++ b/src/net/net-tcp-rpc-ext-server.c
@@ -39,6 +39,7 @@
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
 
+#include "common/ip-utils.h"
 #include "common/kprintf.h"
 #include "common/precise-time.h"
 #include "common/resolver.h"
@@ -316,7 +317,6 @@ static int ip_over_limit (int secret_id, unsigned ip, const unsigned char *ipv6)
   if (limit <= 0) { return 0; }
 
   /* Check if this IP is already tracked (existing connection from same IP) */
-  static const unsigned char zero_ipv6[16] = {};
   for (int i = 0; i < SECRET_MAX_TRACKED_IPS; i++) {
     struct tracked_ip *e = &per_secret_ips[secret_id][i];
     if (e->connections <= 0) { continue; }
@@ -344,8 +344,6 @@ static void ip_track_connect (int secret_id, unsigned ip, const unsigned char *i
   if (ext_secret_max_ips[secret_id] <= 0 && ext_secret_rate_limit[secret_id] <= 0) {
     return;
   }
-
-  static const unsigned char zero_ipv6[16] = {};
 
   /* Find existing entry for this IP */
   for (int i = 0; i < SECRET_MAX_TRACKED_IPS; i++) {
@@ -389,8 +387,6 @@ static void ip_track_connect (int secret_id, unsigned ip, const unsigned char *i
 }
 
 void ip_track_disconnect_impl (int secret_id, unsigned ip, const unsigned char *ipv6) {
-  static const unsigned char zero_ipv6[16] = {};
-
   for (int i = 0; i < SECRET_MAX_TRACKED_IPS; i++) {
     struct tracked_ip *e = &per_secret_ips[secret_id][i];
     if (e->connections <= 0) { continue; }
@@ -433,7 +429,6 @@ void tcp_rpcs_ip_track_clear_slot (int secret_id) {
 
 /* Find the tracked_ip entry for a given IP within a secret's table. */
 static struct tracked_ip *find_tracked_ip (int secret_id, unsigned ip, const unsigned char *ipv6) {
-  static const unsigned char zero_ipv6[16] = {};
   for (int i = 0; i < SECRET_MAX_TRACKED_IPS; i++) {
     struct tracked_ip *e = &per_secret_ips[secret_id][i];
     if (e->connections <= 0) { continue; }

--- a/src/net/net-tcp-rpc-ext-top-ips.c
+++ b/src/net/net-tcp-rpc-ext-top-ips.c
@@ -27,6 +27,7 @@
 
 #include <string.h>
 
+#include "common/ip-utils.h"
 #include "common/precise-time.h"
 #include "net/net-connections.h"
 #include "net/net-tcp-rpc-ext-server.h"
@@ -59,7 +60,6 @@ int tcp_rpcs_get_top_ips_per_secret (void) {
 /* Find an entry matching (ip, ipv6).  Empty slots have ip == 0 and zero ipv6. */
 static struct ip_volume_entry *ip_volume_lookup (int sid, unsigned ip,
                                                  const unsigned char *ipv6) {
-  static const unsigned char zero_ipv6[16] = {};
   for (int i = 0; i < IP_VOLUME_TABLE_SIZE; i++) {
     struct ip_volume_entry *e = &ip_volume[sid][i];
     if (ip != 0) {
@@ -81,7 +81,6 @@ static struct ip_volume_entry *ip_volume_acquire_slot (int sid) {
   for (int i = 0; i < IP_VOLUME_TABLE_SIZE; i++) {
     struct ip_volume_entry *e = &ip_volume[sid][i];
     if (e->ip == 0) {
-      static const unsigned char zero_ipv6[16] = {};
       if (memcmp (e->ipv6, zero_ipv6, 16) == 0) { return e; }
     }
   }
@@ -179,7 +178,6 @@ void tcp_rpcs_snapshot_top_ips (int sid, struct worker_top_ip *out,
       if (picked[i]) { continue; }
       struct ip_volume_entry *e = &ip_volume[sid][i];
       if (e->ip == 0) {
-        static const unsigned char zero_ipv6[16] = {};
         if (memcmp (e->ipv6, zero_ipv6, 16) == 0) { continue; }
       }
       long long total = e->bytes_in + e->bytes_out;


### PR DESCRIPTION
Replaces 11 per-TU `static const unsigned char zero_ipv6[16] = {}` defs across 5 files with a single `extern const` in a shared header.

Before: the `--gc-sections` linker probe reported 11 `.rodata.zero_ipv6.*` removals (per-TU copies that GCC folded at `-O2`). The current `dead-symbols` CI job filters `.text.*` only, so these were not failing the gate, but they were noise the issue called out by name.

After (verified locally via the issue's reproduce command):

```
$ grep -E "removing unused section.*\.rodata\.zero_ipv6" build.log | wc -l
0
```

`.text.*` removals unchanged: the 3 existing accepted inlining artifacts in `net-conn-targets.c` (`count_connection_num`, `fail_connection_gw`, `find_bad_connection`).

Closes the last remaining drain item on the #114 checklist.