### PR TITLE
net: add a timeout increase for the epoll_wait() function

### DIFF
--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -489,7 +489,7 @@ void default_engine_server_start (void) /* {{{ */ {
 
   vkprintf (0, "main loop\n");
   for (;;) {
-    epoll_work (E->epoll_wait_timeout);
+    epoll_work ();
     if (interrupt_signal_raised ()) {
       if (F->on_waiting_exit) {
         while (1) {

--- a/src/net/net-events.c
+++ b/src/net/net-events.c
@@ -362,7 +362,7 @@ double last_epoll_wait_at;
 struct epoll_event new_ev_list[MAX_EVENTS];
 int epoll_sleep_ns = 0;
 
-int epoll_fetch_events (int timeout) {
+int epoll_fetch_events (int ms_timeout) {
   epoll_calls ++;
   int fd, i;
   main_thread_interrupt_status = 1;
@@ -370,7 +370,7 @@ int epoll_fetch_events (int timeout) {
   ts.tv_sec = 0;
   ts.tv_nsec = epoll_sleep_ns;
   nanosleep (&ts, NULL);
-  int res = epoll_wait (epoll_fd, new_ev_list, MAX_EVENTS, timeout);
+  int res = epoll_wait (epoll_fd, new_ev_list, MAX_EVENTS, ms_timeout);
   main_thread_interrupt_status = 0;
   if (res < 0 && errno == EINTR) {
     epoll_intr ++;
@@ -395,23 +395,24 @@ int epoll_fetch_events (int timeout) {
 }
 
 void jobs_check_all_timers (void);
-int epoll_work (int timeout) {
-  int timeout2 = 10000;
+int epoll_work () {
+  int timeout;
+
   if (1) {
     now = time (0);
     get_utime_monotonic ();
     do {
       epoll_runqueue ();
-      timeout2 = epoll_run_timers ();
-    } while ((timeout2 <= 0 || ev_heap_size) && !term_signal_received ());
+      timeout = epoll_run_timers ();
+    } while ((timeout <= 0 || ev_heap_size) && !term_signal_received ());
   }
   if (term_signal_received ()) {
     return 0;
   }
 
-  if (timeout2 < timeout) {
-    timeout = timeout2;
-  }
+  /* increase the short timeout to eliminate unnecessary CPU usage */
+  if (timeout < 100)
+    timeout *= 1000;
 
   double epoll_wait_start = get_utime_monotonic ();
 

--- a/src/net/net-events.h
+++ b/src/net/net-events.h
@@ -88,8 +88,8 @@ int put_event_into_heap (event_t *ev);
 int put_event_into_heap_tail (event_t *ev, int ts_delta);
 
 int epoll_sethandler (int fd, int prio, event_handler_t handler, void *data);
-int epoll_fetch_events (int timeout);
-int epoll_work (int timeout);
+int epoll_fetch_events (int ms_timeout);
+int epoll_work ();
 int epoll_insert (int fd, int flags);
 int epoll_remove (int fd);
 int epoll_close (int fd);


### PR DESCRIPTION
The temporary solution that I suggested in the comments to the PR is not suitable, since the timeout is sometimes equal to 1000 (found this in the logs), and if you constantly multiply it by another 1000, you get something strange.

So I propose a solution with increasing timeouts that are too small, for example < 100 ms, so that they are multiplied by 1000 and passed to epoll_wait().

Refs #129 